### PR TITLE
[W2][D3][징징이] 아바타, 헤더,  서식지 프리뷰 컴포넌트 추가

### DIFF
--- a/front/src/App.test.tsx
+++ b/front/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/front/src/assets/icons/bottom_arrow.svg
+++ b/front/src/assets/icons/bottom_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M7 10L12 15L17 10H7Z" fill="black" />
+</svg>

--- a/front/src/components/Habitat/HabitatPreview.tsx
+++ b/front/src/components/Habitat/HabitatPreview.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import { flexBox } from '../../lib/styles/mixin';
+
+const HabitatPreviewBlock = styled.div<HabitatPreviewProps>`
+  position: absolute;
+  width: 500px;
+  height: 500px;
+  border-radius: 50%;
+  top: 25vh;
+  background: ${({ color }) => color};
+
+  ${flexBox('center', null, 'column')}
+
+  ${({ side }) => {
+    return side === 'right'
+      ? `
+    right: -250px;
+    align-items: flex-start;
+    `
+      : `
+      left:-250px;
+      align-items: flex-end;
+      `;
+  }};
+  padding: 100px;
+`;
+
+interface HabitatPreviewProps {
+  side: string;
+  color: string;
+}
+
+const HabitatPreview = ({ side, color }: HabitatPreviewProps) => {
+  return (
+    <HabitatPreviewBlock side={side} color={color}>
+      <div>avatars</div>
+      <div>마리의 동물들</div>
+      <div>의 게시글</div>
+      <div>최근 활동: </div>
+      <div>우두머리</div>
+      <div>장소</div>
+    </HabitatPreviewBlock>
+  );
+};
+
+export default HabitatPreview;

--- a/front/src/components/Habitat/HabitatPreview.tsx
+++ b/front/src/components/Habitat/HabitatPreview.tsx
@@ -3,27 +3,27 @@ import styled from 'styled-components';
 import { flexBox } from '../../lib/styles/mixin';
 
 const HabitatPreviewBlock = styled.div<HabitatPreviewProps>`
+  ${flexBox('center', null, 'column')}
+
   position: absolute;
   width: 500px;
   height: 500px;
   border-radius: 50%;
   top: 25vh;
   background: ${({ color }) => color};
-
-  ${flexBox('center', null, 'column')}
+  padding: 100px;
 
   ${({ side }) => {
-    return side === 'right'
-      ? `
-    right: -250px;
-    align-items: flex-start;
-    `
-      : `
-      left:-250px;
+    const leftTemplate = `
+      left: -250px;
       align-items: flex-end;
-      `;
+    `;
+    const rightTemplate = `
+      right: -250px;
+      align-items: flex-start;
+    `;
+    return side === 'right' ? rightTemplate : leftTemplate;
   }};
-  padding: 100px;
 `;
 
 interface HabitatPreviewProps {

--- a/front/src/components/Habitat/index.test.tsx
+++ b/front/src/components/Habitat/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+describe('Habitat 컴포넌트 테스트', function () {
+  it('HabitatPreview 컴포넌트는 props를 받아서 화면에 출력한다', function () {
+    //todo: 테스트 작성해야함
+  });
+});

--- a/front/src/components/Header/Header.tsx
+++ b/front/src/components/Header/Header.tsx
@@ -1,0 +1,29 @@
+import { Palette } from '../../lib/styles/palette';
+import React from 'react';
+import styled from 'styled-components';
+import Place from './Place';
+import UserInfo from './UserInfo';
+import { flexBox } from '../../lib/styles/mixin';
+
+const LOGO: string = '핑핑이 친구들';
+
+const HeaderBlock = styled.div`
+  display: flex;
+  width: 100%;
+  height: 54px;
+  padding: 0 12px;
+  border-bottom: solid ${Palette.gray} 1px;
+  ${flexBox('space-between', 'center')}
+`;
+
+const Header = () => {
+  return (
+    <HeaderBlock>
+      <div className={'Logo'}>{LOGO}</div>
+      <Place />
+      <UserInfo />
+    </HeaderBlock>
+  );
+};
+
+export default Header;

--- a/front/src/components/Header/Header.tsx
+++ b/front/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Palette } from '../../lib/styles/palette';
+import { Palette } from '../../lib/styles/Palette';
 import React from 'react';
 import styled from 'styled-components';
 import Place from './Place';

--- a/front/src/components/Header/Header.tsx
+++ b/front/src/components/Header/Header.tsx
@@ -12,8 +12,7 @@ const HeaderBlock = styled.div`
   width: 100%;
   height: 54px;
   padding: 0 12px;
-  border-bottom: solid ${Palette.gray} 1px;
-  ${flexBox('space-between', 'center')}
+  border-bottom: solid ${Palette.GRAY} 1px;
 `;
 
 const Header = () => {

--- a/front/src/components/Header/Header.tsx
+++ b/front/src/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import { flexBox } from '../../lib/styles/mixin';
 const LOGO: string = '핑핑이 친구들';
 
 const HeaderBlock = styled.div`
-  display: flex;
+  ${flexBox('space-between', 'center')};
   width: 100%;
   height: 54px;
   padding: 0 12px;

--- a/front/src/components/Header/Place.tsx
+++ b/front/src/components/Header/Place.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Palette } from '../../lib/styles/palette';
+import { Palette } from '../../lib/styles/Palette';
 import { flexBox } from '../../lib/styles/mixin';
 
 const PlaceBlock = styled.div`

--- a/front/src/components/Header/Place.tsx
+++ b/front/src/components/Header/Place.tsx
@@ -7,7 +7,7 @@ const PlaceBlock = styled.div`
   ${flexBox()}
 
   border-radius: 10px;
-  border: 1px solid ${Palette.gray};
+  border: 1px solid ${Palette.GRAY};
   width: 200px;
   padding: 12px;
   &:hover {

--- a/front/src/components/Header/Place.tsx
+++ b/front/src/components/Header/Place.tsx
@@ -4,6 +4,8 @@ import { Palette } from '../../lib/styles/palette';
 import { flexBox } from '../../lib/styles/mixin';
 
 const PlaceBlock = styled.div`
+  ${flexBox()}
+
   border-radius: 10px;
   border: 1px solid ${Palette.gray};
   width: 200px;
@@ -11,7 +13,6 @@ const PlaceBlock = styled.div`
   &:hover {
     cursor: pointer;
   }
-  ${flexBox()}
 `;
 
 interface PlaceProps {

--- a/front/src/components/Header/Place.tsx
+++ b/front/src/components/Header/Place.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Palette } from '../../lib/styles/palette';
+import { flexBox } from '../../lib/styles/mixin';
+
+const PlaceBlock = styled.div`
+  border-radius: 10px;
+  border: 1px solid ${Palette.gray};
+  width: 200px;
+  padding: 12px;
+  &:hover {
+    cursor: pointer;
+  }
+  ${flexBox()}
+`;
+
+interface PlaceProps {
+  habitat?: string;
+}
+
+const Place = ({ habitat = '서식지' }: PlaceProps) => {
+  return <PlaceBlock> {habitat} </PlaceBlock>;
+};
+
+export default Place;

--- a/front/src/components/Header/UserInfo.tsx
+++ b/front/src/components/Header/UserInfo.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import Avatar from '../_common/Avatar/Avatar';
+import { flexBox } from '../../lib/styles/mixin';
+
+const UserInfoBlock = styled.div`
+  ${flexBox('center', 'flex-end')}
+  .username {
+    margin-right: 5px;
+  }
+`;
+
+interface UserInfoProps {
+  username?: string;
+}
+
+const UserInfo = ({ username = '핑핑이' }: UserInfoProps) => {
+  return (
+    <UserInfoBlock>
+      <div className={'username'}>{username}</div>
+      <Avatar />
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M7 10L12 15L17 10H7Z" fill="black" />
+      </svg>
+    </UserInfoBlock>
+  );
+};
+
+export default UserInfo;

--- a/front/src/components/Header/UserInfo.tsx
+++ b/front/src/components/Header/UserInfo.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Avatar from '../_common/Avatar/Avatar';
 import { flexBox } from '../../lib/styles/mixin';
+import { ReactComponent as BottomArrow } from '../../assets/icons/bottom_arrow.svg';
 
 const UserInfoBlock = styled.div`
   ${flexBox('center', 'flex-end')}
@@ -19,9 +20,7 @@ const UserInfo = ({ username = '핑핑이' }: UserInfoProps) => {
     <UserInfoBlock>
       <div className={'username'}>{username}</div>
       <Avatar />
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M7 10L12 15L17 10H7Z" fill="black" />
-      </svg>
+      <BottomArrow />
     </UserInfoBlock>
   );
 };

--- a/front/src/components/Header/index.test.tsx
+++ b/front/src/components/Header/index.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Place from './Place';
+import UserInfo from './UserInfo';
+
+describe('Header 컴포넌트 테스트', function () {
+  it('Place 컴포넌트는 서식지를 받아서 화면에 출력한다', function () {
+    render(<Place habitat={'강남역'} />);
+    const text = screen.getByText(/강남역/i);
+    expect(text).toBeInTheDocument();
+  });
+  it('UserInfo 컴포넌트는 유저 네임을 받아서 화면에 출력한다', function () {
+    render(<UserInfo username={'핑핑이'} />);
+    const text = screen.getByText(/핑핑이/i);
+    expect(text).toBeInTheDocument();
+  });
+
+  it('Header 컴포넌트는 Logo, UserInfo, Avatar, Place를 렌더링한다', function () {
+    //todo: 테스트 작성해야함
+  });
+});

--- a/front/src/components/_common/Avatar/Avatar.tsx
+++ b/front/src/components/_common/Avatar/Avatar.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export const DEFAULT_IMG_SRC = `https://user-images.githubusercontent.com/45571631/140061082-73c5bc5a-4505-4bc2-a03e-debeb693e74f.png`;
+
+const AvatarBlock = styled.div`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+interface AvatarProps {
+  imgSrc?: string;
+}
+
+const Avatar = ({ imgSrc }: AvatarProps) => {
+  return <AvatarBlock>{imgSrc ? <img src={imgSrc} alt="로그인 이미지" /> : <img src={DEFAULT_IMG_SRC} alt="로그아웃 이미지" />}</AvatarBlock>;
+};
+
+export default Avatar;

--- a/front/src/components/_common/Avatar/index.test.tsx
+++ b/front/src/components/_common/Avatar/index.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Avatar, { DEFAULT_IMG_SRC } from './Avatar';
+
+describe('Avatar 컴포넌트 테스트', function () {
+  it('Avatar 이미지 url을 받아서 화면에 출력한다', function () {
+    const testURL = `https://testURL.png/`;
+    render(<Avatar imgSrc={testURL} />);
+    const urlText = screen.getByRole('img') as HTMLImageElement;
+    expect(urlText.src).toBe(testURL.toLowerCase());
+  });
+  it('Avatar 이미지 url을 받지 않으면 기본 url을 출력한다', function () {
+    render(<Avatar />);
+    const urlText = screen.getByRole(`img`) as HTMLImageElement;
+    expect(urlText.src).toBe(DEFAULT_IMG_SRC);
+  });
+});

--- a/front/src/lib/styles/Palette.ts
+++ b/front/src/lib/styles/Palette.ts
@@ -1,0 +1,8 @@
+export enum Palette {
+  GRAY = '#5B5759',
+  SKYBLUE = '#B5E8E2',
+  BLUE = '#7ADDD1',
+  PINK = '#FFB1B9',
+  APRICOT = '#FACBBA',
+  ORANGE = '#F0CC96',
+}

--- a/front/src/lib/styles/mixin.ts
+++ b/front/src/lib/styles/mixin.ts
@@ -1,0 +1,11 @@
+import { css } from 'styled-components';
+
+type FlexOption = 'center' | 'flex-start' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly' | null;
+type Direction = 'column' | 'row' | null;
+
+export const flexBox = (justify: FlexOption = 'center', align: FlexOption = 'center', direction: Direction = 'row') => css`
+  display: flex;
+  justify-content: ${justify};
+  align-items: ${align};
+  flex-direction: ${direction};
+`;

--- a/front/src/lib/styles/palette.ts
+++ b/front/src/lib/styles/palette.ts
@@ -1,8 +1,0 @@
-export enum Palette {
-  gray = '#5B5759',
-  skyblue = '#B5E8E2',
-  blue = '#7ADDD1',
-  pink = '#FFB1B9',
-  apricot = '#FACBBA',
-  orange = '#F0CC96',
-}

--- a/front/src/lib/styles/palette.ts
+++ b/front/src/lib/styles/palette.ts
@@ -1,0 +1,8 @@
+export enum Palette {
+  gray = '#5B5759',
+  skyblue = '#B5E8E2',
+  blue = '#7ADDD1',
+  pink = '#FFB1B9',
+  apricot = '#FACBBA',
+  orange = '#F0CC96',
+}

--- a/front/src/reset.css
+++ b/front/src/reset.css
@@ -1,4 +1,5 @@
 * {
   padding: 0;
   margin: 0;
+  box-sizing: border-box;
 }

--- a/front/src/setupTests.ts
+++ b/front/src/setupTests.ts
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';


### PR DESCRIPTION
### 작업 내역
---
- [x] 아바타 컴포넌트
- [x] 헤더 컴포넌트
- [x] 서식지 프리뷰 컴포넌트

### 고민 및 해결
---

- #13 에서 삭제했던 `setupTests.ts`파일이 테스트 코드 작성시에 사용되는 파일이어서 다시 복구
- 타입 선언시 `type` 와 `interface` 에 대해 얘기를 해봐야할 것 같다
- 프로젝트 내부에서 전역적으로 사용할 컬러에 대해 `styled-component`의 `ThemeProvider`를 꼭 사용해야할까?
- 자주 사용되는 스타일인 `display: flex;` 및 이하의 옵션들을 반복적으로 주기 번거롭다
    - 생산성을 위해 `flexBox` mixin으로 구현 해봤는데 피드백이 필요함
- `styled`된 컴포넌트에 대한 컨벤션도 필요할 것 같다

- img vs div background 태그


### 데모 이미지
---

<img width="1440" alt="demo" src="https://user-images.githubusercontent.com/45571631/140103744-1c898d13-7817-4164-8cb0-83fe29968141.png">


close #15 #18 #19 #23