### PR TITLE
[W3][D1][다람이] 글쓰기 버튼 위치 반응형 & 피드 드롭박스

### DIFF
--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -1,10 +1,10 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { ReactComponent as VertBtnSvg } from '../../assets/icons/more_vert_btn.svg';
 import { ReactComponent as HeartBtnSvg } from '../../assets/icons/empty_heart_btn.svg';
 import { ReactComponent as CommentBtnSvg } from '../../assets/icons/comment_btn.svg';
 import Avatar from '../_common/Avatar/Avatar';
-import DropBox, { dropboxRefHandler } from '../_common/DropBox/DropBox';
+import DropBox from '../_common/DropBox/DropBox';
 import { flexBox } from '../../lib/styles/mixin';
 
 export interface FeedJson {
@@ -67,20 +67,15 @@ const FeedTextDiv = styled.div`
 `;
 
 const Feed = ({ json }: { json: FeedJson }) => {
-  const dropBoxEl = useRef<dropboxRefHandler>();
-  const toggleDropBox = () => {
-    if (dropBoxEl.current) {
-      dropBoxEl.current.toggle();
-    }
-  };
   const dropboxItems = ['글 삭제', '글 수정'];
   return (
     <FeedContainerDiv>
       <FeedHeaderDiv>
         <Avatar />
         <span>{json.nickname}</span>
-        <VertBtnSvg className="vert_btn button" onClick={toggleDropBox} />
-        <DropBox ref={dropBoxEl} start="right" offset={10} top={55} width={150} items={dropboxItems} />
+        <DropBox start="right" offset={10} top={55} width={150} items={dropboxItems}>
+          <VertBtnSvg className="vert_btn button" />
+        </DropBox>
       </FeedHeaderDiv>
       <FeedContents imageURL={json.imageURL} />
       <FeedInfoDiv>

--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as VertBtnSvg } from '../../assets/icons/more_vert_btn.svg';
 import { ReactComponent as HeartBtnSvg } from '../../assets/icons/empty_heart_btn.svg';
 import { ReactComponent as CommentBtnSvg } from '../../assets/icons/comment_btn.svg';
 import Avatar from '../_common/Avatar/Avatar';
+import DropBox, { dropboxRefHandler } from '../_common/DropBox/DropBox';
 import { flexBox } from '../../lib/styles/mixin';
 
 export interface FeedJson {
@@ -66,12 +67,20 @@ const FeedTextDiv = styled.div`
 `;
 
 const Feed = ({ json }: { json: FeedJson }) => {
+  const dropBoxEl = useRef<dropboxRefHandler>();
+  const toggleDropBox = () => {
+    if (dropBoxEl.current) {
+      dropBoxEl.current.toggle();
+    }
+  };
+  const dropboxItems = ['글 삭제', '글 수정'];
   return (
     <FeedContainerDiv>
       <FeedHeaderDiv>
         <Avatar />
         <span>{json.nickname}</span>
-        <VertBtnSvg className="vert_btn" />
+        <VertBtnSvg className="vert_btn button" onClick={toggleDropBox} />
+        <DropBox ref={dropBoxEl} start="right" offset={10} top={55} width={150} items={dropboxItems} />
       </FeedHeaderDiv>
       <FeedContents imageURL={json.imageURL} />
       <FeedInfoDiv>

--- a/front/src/components/Feed/FeedFAB.tsx
+++ b/front/src/components/Feed/FeedFAB.tsx
@@ -22,9 +22,17 @@ const FeedFAB = () => {
   const floatingEl = useRef<HTMLDivElement>(null);
   const FEED_SECTION_WIDTH: number = 500;
   const FAB_OFFSET: number = 10;
+  const changeResponsivePosition = () => {
+    const newPos: number = (window.innerWidth + FEED_SECTION_WIDTH) / 2;
+    if (floatingEl.current !== null) floatingEl.current.style.left = newPos + FAB_OFFSET + 'px';
+  };
+
   useEffect(() => {
-    const fabPos: number = (window.innerWidth + FEED_SECTION_WIDTH) / 2;
-    if (floatingEl.current !== null) floatingEl.current.style.left = fabPos + FAB_OFFSET + 'px';
+    changeResponsivePosition();
+    window.addEventListener('resize', changeResponsivePosition);
+    return () => {
+      window.removeEventListener('resize', changeResponsivePosition);
+    };
   }, []);
 
   return (

--- a/front/src/components/_common/DropBox/DropBox.tsx
+++ b/front/src/components/_common/DropBox/DropBox.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useRef } from 'react';
+import React, { ReactElement, useState } from 'react';
 import styled from 'styled-components';
 import { Palette } from '../../../lib/styles/Palette';
 
@@ -8,13 +8,13 @@ export interface DropBoxProps {
   top: number;
   width: number;
   items: string[];
+  children: ReactElement;
 }
 
 const DROPBOX_ITEM_HEIGHT = '40px';
 const DROPBOX_BORDER_RADIUS = '7px';
 
 const DropBoxDiv = styled.div<any>`
-  display: none;
   width: ${(props) => props.width}px;
   height: max-content;
   background-color: ${Palette.WHITE};
@@ -54,27 +54,20 @@ const DropBoxDiv = styled.div<any>`
   }
 `;
 
-export interface dropboxRefHandler {
-  toggle: () => void;
-}
-
-const DropBox = React.forwardRef(({ start, offset, top, width, items }: DropBoxProps, ref: any) => {
-  const dropboxEl = useRef<HTMLDivElement>();
-  useImperativeHandle(ref, () => ({
-    toggle: () => {
-      if (dropboxEl.current) {
-        if (dropboxEl.current.style.display === 'block') dropboxEl.current.style.display = 'none';
-        else dropboxEl.current.style.display = 'block';
-      }
-    },
-  }));
+const DropBox = ({ start, offset, top, width, items, children }: DropBoxProps) => {
+  const [isDroped, setDrop] = useState(false);
   return (
-    <DropBoxDiv ref={dropboxEl} start={start} offset={offset} top={top} width={width}>
-      {items.map((str, idx) => (
-        <p key={idx}>{str}</p>
-      ))}
-    </DropBoxDiv>
+    <>
+      {React.cloneElement(children, { onClick: () => setDrop(!isDroped) })}
+      {isDroped ? (
+        <DropBoxDiv start={start} offset={offset} top={top} width={width}>
+          {items.map((str, idx) => (
+            <p key={idx}>{str}</p>
+          ))}
+        </DropBoxDiv>
+      ) : null}
+    </>
   );
-});
+};
 
 export default DropBox;

--- a/front/src/components/_common/DropBox/DropBox.tsx
+++ b/front/src/components/_common/DropBox/DropBox.tsx
@@ -1,0 +1,80 @@
+import React, { useImperativeHandle, useRef } from 'react';
+import styled from 'styled-components';
+import { Palette } from '../../../lib/styles/Palette';
+
+export interface DropBoxProps {
+  start: 'left' | 'right';
+  offset: number;
+  top: number;
+  width: number;
+  items: string[];
+}
+
+const DROPBOX_ITEM_HEIGHT = '40px';
+const DROPBOX_BORDER_RADIUS = '7px';
+
+const DropBoxDiv = styled.div<any>`
+  display: none;
+  width: ${(props) => props.width}px;
+  height: max-content;
+  background-color: ${Palette.WHITE};
+  position: absolute;
+  ${(props) => `${props.start}:${props.offset}px`};
+  top: ${(props) => props.top}px;
+  z-index: 10;
+  border-radius: ${DROPBOX_BORDER_RADIUS};
+  box-shadow: 0px 4px 10px rgba(51, 51, 51, 1), 0px 0px 4px rgba(51, 51, 51, 0.5);
+  p {
+    font-size: 12px;
+    height: ${DROPBOX_ITEM_HEIGHT};
+    line-height: ${DROPBOX_ITEM_HEIGHT};
+    padding: 0 20px;
+
+    &:after {
+      display: block;
+      content: '';
+      border-bottom: 1px solid #afafaf;
+      position: relative;
+      top: -1px;
+    }
+    &:last-child:after {
+      border: none;
+    }
+    &:hover {
+      background-color: ${Palette.BACKGROUND_GRAY};
+      &:first-child {
+        border-top-left-radius: ${DROPBOX_BORDER_RADIUS};
+        border-top-right-radius: ${DROPBOX_BORDER_RADIUS};
+      }
+      &:last-child {
+        border-bottom-left-radius: ${DROPBOX_BORDER_RADIUS};
+        border-bottom-right-radius: ${DROPBOX_BORDER_RADIUS};
+      }
+    }
+  }
+`;
+
+export interface dropboxRefHandler {
+  toggle: () => void;
+}
+
+const DropBox = React.forwardRef(({ start, offset, top, width, items }: DropBoxProps, ref: any) => {
+  const dropboxEl = useRef<HTMLDivElement>();
+  useImperativeHandle(ref, () => ({
+    toggle: () => {
+      if (dropboxEl.current) {
+        if (dropboxEl.current.style.display === 'block') dropboxEl.current.style.display = 'none';
+        else dropboxEl.current.style.display = 'block';
+      }
+    },
+  }));
+  return (
+    <DropBoxDiv ref={dropboxEl} start={start} offset={offset} top={top} width={width}>
+      {items.map((str, idx) => (
+        <p key={idx}>{str}</p>
+      ))}
+    </DropBoxDiv>
+  );
+});
+
+export default DropBox;

--- a/front/src/global.css
+++ b/front/src/global.css
@@ -1,0 +1,3 @@
+.button {
+  cursor: pointer;
+}

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import './reset.css';
+import './global.css';
 
 import App from './App';
 ReactDOM.render(


### PR DESCRIPTION
### 작업 내역
---
- [x] 글쓰기 버튼 반응형으로 바꾸기
- [x] 피드 (수정/삭제) 드롭다운 메뉴

### 고민 및 해결
---
1. 렌더링 후에 window에 resize 이벤트리스너를 추가하여 resize 될때마다 새로 위치 계산하도록 구현하였다. cleanup을 통해 컴포넌트 사라질때 resize 이벤트리스너 제거해주었다.
2. 드랍박스는 재사용 가능한 형태로 구현하였다.
3. useState로 드랍박스 상태를 다루면 드롭박스가 나타날때마다 피드 자체가 재랜더링되는 이슈가 있었다. 이를 해결하기 위해 ref로 드롭박스 컴포넌트를 가리키고 직접 스타일을 다루려고 했느데 함수형 컴포넌트는 ref 할당이 불가능하였다[[참고]](https://ko.reactjs.org/docs/refs-and-the-dom.html#refs-and-function-components). 결과적으로 `forwardRef`를 통해 ref 를 전달하고 `useImperativeHandle` 훅을 통해 ref에 대한 메소드를 전달하였다. 
4. styled component 에서 ref와 props를 동시에 사용하는 경우 타입을 어떻게 해야하는지 모르겠다...

### (필요시) 데모 이미지
---
![demo](https://user-images.githubusercontent.com/63776725/140787387-e389468b-c583-4526-a647-b23eb10e8a7f.gif)
