### PR TITLE
[W3][D2][뚱이] Post API

### DIFF
--- a/back/src/post/dto/create-post.dto.ts
+++ b/back/src/post/dto/create-post.dto.ts
@@ -1,1 +1,6 @@
-export class CreatePostDto {}
+export class CreatePostDto {
+  userId: number;
+  habitatId: number;
+  humanContent: string;
+  animalContent: string;
+}

--- a/back/src/post/entities/post.entity.ts
+++ b/back/src/post/entities/post.entity.ts
@@ -15,6 +15,12 @@ export class Post {
   @Column({ length: 500, name: 'animal_content' })
   animalContent: string;
 
+  @Column({ name: 'user_id' })
+  userId: number;
+
+  @Column({ name: 'habitat_id' })
+  habitatId: number;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
@@ -12,12 +12,12 @@ export class PostController {
     return this.postService.create(createPostDto);
   }
 
-  @Get()
-  findAll() {
-    return this.postService.findAll();
+  @Get(':habitatId')
+  findAll(@Param('habitatId') habitatId: string, @Query('skip') skip: string, @Query('take') take: string) {
+    return this.postService.findAll(+habitatId, +skip, +take);
   }
 
-  @Get(':id')
+  @Get(':habitatId/:id')
   findOne(@Param('id') id: string) {
     return this.postService.findOne(+id);
   }

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -1,15 +1,19 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, Req, Res } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { Request, Response } from 'express';
+import { S3Service } from 'src/s3/s3.service';
 
 @Controller('post')
 export class PostController {
-  constructor(private readonly postService: PostService) {}
+  constructor(private readonly postService: PostService, private readonly s3Servise: S3Service) {}
 
   @Post()
-  create(@Body() createPostDto: CreatePostDto) {
-    return this.postService.create(createPostDto);
+  async create(@Req() req: Request, @Res() res: Response, @Body() createPostDto: CreatePostDto) {
+    console.log(createPostDto);
+    const contentsInfos = (await this.s3Servise.uploadS3(req, res)) as any[];
+    return this.postService.create(createPostDto, contentsInfos);
   }
 
   @Get(':habitatId')

--- a/back/src/post/post.module.ts
+++ b/back/src/post/post.module.ts
@@ -3,10 +3,14 @@ import { PostService } from './post.service';
 import { PostController } from './post.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
+import { S3Module } from 'src/s3/s3.module';
+import { S3Service } from 'src/s3/s3.service';
+import { PostContent } from 'src/post-contents/entities/post-content.entity';
+import { Content } from 'src/contents/entities/content.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post])],
+  imports: [TypeOrmModule.forFeature([Post, PostContent, Content]), S3Module],
   controllers: [PostController],
-  providers: [PostService],
+  providers: [PostService, S3Service],
 })
 export class PostModule {}

--- a/back/src/post/post.service.ts
+++ b/back/src/post/post.service.ts
@@ -36,6 +36,6 @@ export class PostService {
   }
 
   remove(id: number) {
-    return `This action removes a #${id} post`;
+    return this.postRepository.delete(id);
   }
 }

--- a/back/src/post/post.service.ts
+++ b/back/src/post/post.service.ts
@@ -1,15 +1,30 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { Post } from './entities/post.entity';
 
 @Injectable()
 export class PostService {
+  constructor(@InjectRepository(Post) private postRepository: Repository<Post>) {}
+
   create(createPostDto: CreatePostDto) {
     return 'This action adds a new post';
   }
 
-  findAll() {
-    return `This action returns all post`;
+  findAll(habitatId: number, skip: number, take: number) {
+    return this.postRepository
+      .createQueryBuilder('post')
+      .innerJoinAndSelect('post.user', 'user', 'post.userId = user.id')
+      .innerJoinAndSelect('user.content', 'content')
+      .loadRelationCountAndMap('post.numOfLikes', 'post.likingUser', 'user')
+      .loadRelationCountAndMap('post.numOfComments', 'post.comments', 'comments')
+      .where('post.habitatId = :habitatId ', { habitatId: habitatId })
+      .orderBy('post.id', 'DESC')
+      .skip(skip)
+      .take(take)
+      .getMany();
   }
 
   findOne(id: number) {

--- a/back/src/post/post.service.ts
+++ b/back/src/post/post.service.ts
@@ -28,7 +28,7 @@ export class PostService {
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} post`;
+    return this.postRepository.findOne(id, { relations: ['user', 'user.content', 'comments', 'comments.user', 'comments.user.content', 'postContents', 'postContents.content', 'likingUser'] });
   }
 
   update(id: number, updatePostDto: UpdatePostDto) {


### PR DESCRIPTION
### 작업 내역
---
- [ ] 게시글 추가 API
- [x] 게시글 리스트 페이징 해서 보내주는 API
- [x] 게시글 상세보기 API
- [ ] 특정 유저의 게시글 목록 조회 API
- [x] 게시글 삭제 API
- [ ] 게시글 수정 API

### 고민 및 해결
---
특정 유저의 게시글 목록 조회는 이 기능이 user service에 있는 게 맞는지, post service에 있는 게 맞는지 확신이 서질 않아서, 이 기능은 마이페이지 할때 해도 좋을 것 같음

게시글 추가 API는 코드까지 짰으나 Postman으로 파일과 json 데이터를 함께 보내는 방법을 몰라 테스트를 못해봄. 도처히 못 찾겠음. 파일이 Object Storage에 업로드 되고, url 반환하는 것까지 확인했음. 테이블에 데이터 저장이 되는지만 확인하면 됨.

게시글 수정에서 고려해야할 것이, 사진을 삭제하거나 더 추가했을 때 어떻게 처리해야할지 감이 오지 않음 함께 얘기 해봤으면 좋겠음. 

게시글 삭제의 경우 manyToOne relation의 Entity에서 {onDelete: "Cascade"} 옵션을 넣어줘야됨. conflict 날 까봐 일단 건들지 않음.

쿼리를 작성해보니 join문이 많아지는 건 어쩔 수 없는 것 같음 .
api 후딱 할 줄 알았는데, 이것저것 고려해야할게 첩첩산중이었다.

### (필요시) 데모 이미지
---

##### 게시글 상세 보기
![image](https://user-images.githubusercontent.com/58130501/141000889-d847a298-a26b-48e1-8739-78f533799263.png)

##### 페이징 해서 보여주기
![image](https://user-images.githubusercontent.com/58130501/141001108-0d820a0c-b9fb-499e-90d5-1f6c50c09a74.png)

##### 