### PR TITLE
[W3][D3][뚱이] 피드 API

### DIFF
--- a/back/src/app.module.ts
+++ b/back/src/app.module.ts
@@ -11,10 +11,11 @@ import { HabitatModule } from './habitat/habitat.module';
 import { FollowModule } from './follow/follow.module';
 import { SpeciesModule } from './species/species.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { HeartsModule } from './hearts/hearts.module';
 import databaseConfig from './database/database.config';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(databaseConfig), UsersModule, S3Module, ContentsModule, PostContentsModule, PostModule, CommentModule, HabitatModule, FollowModule, SpeciesModule],
+  imports: [TypeOrmModule.forRoot(databaseConfig), UsersModule, S3Module, ContentsModule, PostContentsModule, PostModule, CommentModule, HabitatModule, FollowModule, SpeciesModule, HeartsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/back/src/contents/dto/create-content.dto.ts
+++ b/back/src/contents/dto/create-content.dto.ts
@@ -1,1 +1,4 @@
-export class CreateContentDto {}
+export class CreateContentDto {
+  url: string;
+  mimeType: string;
+}

--- a/back/src/hearts/dto/create-heart.dto.ts
+++ b/back/src/hearts/dto/create-heart.dto.ts
@@ -1,0 +1,1 @@
+export class CreateHeartDto {}

--- a/back/src/hearts/dto/update-heart.dto.ts
+++ b/back/src/hearts/dto/update-heart.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateHeartDto } from './create-heart.dto';
+
+export class UpdateHeartDto extends PartialType(CreateHeartDto) {}

--- a/back/src/hearts/entities/heart.entity.ts
+++ b/back/src/hearts/entities/heart.entity.ts
@@ -1,0 +1,20 @@
+import { Post } from 'src/post/entities/post.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class Heart {
+  @PrimaryColumn({ name: 'user_id' })
+  userId: number;
+
+  @PrimaryColumn({ name: 'post_id' })
+  postId: number;
+
+  @ManyToOne(() => User, (user) => user.hearts)
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  user: User;
+
+  @ManyToOne(() => Post, (post) => post.hearts)
+  @JoinColumn({ name: 'post_id', referencedColumnName: 'id' })
+  post: Post;
+}

--- a/back/src/hearts/entities/heart.entity.ts
+++ b/back/src/hearts/entities/heart.entity.ts
@@ -10,11 +10,11 @@ export class Heart {
   @PrimaryColumn({ name: 'post_id' })
   postId: number;
 
-  @ManyToOne(() => User, (user) => user.hearts)
+  @ManyToOne(() => User)
   @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
   user: User;
 
-  @ManyToOne(() => Post, (post) => post.hearts)
+  @ManyToOne(() => Post)
   @JoinColumn({ name: 'post_id', referencedColumnName: 'id' })
   post: Post;
 }

--- a/back/src/hearts/hearts.controller.spec.ts
+++ b/back/src/hearts/hearts.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HeartsController } from './hearts.controller';
+import { HeartsService } from './hearts.service';
+
+describe('HeartsController', () => {
+  let controller: HeartsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HeartsController],
+      providers: [HeartsService],
+    }).compile();
+
+    controller = module.get<HeartsController>(HeartsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/back/src/hearts/hearts.controller.ts
+++ b/back/src/hearts/hearts.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { HeartsService } from './hearts.service';
+import { CreateHeartDto } from './dto/create-heart.dto';
+import { UpdateHeartDto } from './dto/update-heart.dto';
+
+@Controller('hearts')
+export class HeartsController {
+  constructor(private readonly heartsService: HeartsService) {}
+
+  @Post()
+  create(@Body() createHeartDto: CreateHeartDto) {
+    return this.heartsService.create(createHeartDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.heartsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.heartsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateHeartDto: UpdateHeartDto) {
+    return this.heartsService.update(+id, updateHeartDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.heartsService.remove(+id);
+  }
+}

--- a/back/src/hearts/hearts.controller.ts
+++ b/back/src/hearts/hearts.controller.ts
@@ -17,9 +17,9 @@ export class HeartsController {
     return this.heartsService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.heartsService.findOne(+id);
+  @Get(':userId/:postId')
+  async findOne(@Param('userId') userId: string, @Param('postId') postId: string) {
+    return await this.heartsService.findOne(+userId, +postId);
   }
 
   @Patch(':id')

--- a/back/src/hearts/hearts.module.ts
+++ b/back/src/hearts/hearts.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { HeartsService } from './hearts.service';
 import { HeartsController } from './hearts.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Heart } from './entities/heart.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Heart])],
   controllers: [HeartsController],
-  providers: [HeartsService]
+  providers: [HeartsService],
 })
 export class HeartsModule {}

--- a/back/src/hearts/hearts.module.ts
+++ b/back/src/hearts/hearts.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HeartsService } from './hearts.service';
+import { HeartsController } from './hearts.controller';
+
+@Module({
+  controllers: [HeartsController],
+  providers: [HeartsService]
+})
+export class HeartsModule {}

--- a/back/src/hearts/hearts.service.spec.ts
+++ b/back/src/hearts/hearts.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HeartsService } from './hearts.service';
+
+describe('HeartsService', () => {
+  let service: HeartsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HeartsService],
+    }).compile();
+
+    service = module.get<HeartsService>(HeartsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/back/src/hearts/hearts.service.ts
+++ b/back/src/hearts/hearts.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateHeartDto } from './dto/create-heart.dto';
+import { UpdateHeartDto } from './dto/update-heart.dto';
+
+@Injectable()
+export class HeartsService {
+  create(createHeartDto: CreateHeartDto) {
+    return 'This action adds a new heart';
+  }
+
+  findAll() {
+    return `This action returns all hearts`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} heart`;
+  }
+
+  update(id: number, updateHeartDto: UpdateHeartDto) {
+    return `This action updates a #${id} heart`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} heart`;
+  }
+}

--- a/back/src/hearts/hearts.service.ts
+++ b/back/src/hearts/hearts.service.ts
@@ -1,9 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateHeartDto } from './dto/create-heart.dto';
 import { UpdateHeartDto } from './dto/update-heart.dto';
+import { Heart } from './entities/heart.entity';
 
 @Injectable()
 export class HeartsService {
+  constructor(
+    @InjectRepository(Heart)
+    private heartRepository: Repository<Heart>
+  ) {}
+
   create(createHeartDto: CreateHeartDto) {
     return 'This action adds a new heart';
   }
@@ -12,8 +20,8 @@ export class HeartsService {
     return `This action returns all hearts`;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} heart`;
+  async findOne(userId: number, postId: number) {
+    return await this.heartRepository.createQueryBuilder('heart').where('heart.postId = :postId AND heart.userId = :userId', { postId: postId, userId: userId }).getCount();
   }
 
   update(id: number, updateHeartDto: UpdateHeartDto) {

--- a/back/src/post/entities/post.entity.ts
+++ b/back/src/post/entities/post.entity.ts
@@ -1,5 +1,6 @@
 import { Comment } from 'src/comment/entities/comment.entity';
 import { Habitat } from 'src/habitat/entities/habitat.entity';
+import { Heart } from 'src/hearts/entities/heart.entity';
 import { PostContent } from 'src/post-contents/entities/post-content.entity';
 import { User } from 'src/users/entities/user.entity';
 import { Column, CreateDateColumn, Entity, JoinColumn, JoinTable, ManyToMany, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
@@ -32,13 +33,8 @@ export class Post {
   @JoinColumn({ name: 'habitat_id', referencedColumnName: 'id' })
   habitat: Habitat;
 
-  @ManyToMany(() => User, (user) => user.likedPost)
-  @JoinTable({
-    name: 'liked',
-    joinColumn: { name: 'post_id', referencedColumnName: 'id' },
-    inverseJoinColumn: { name: 'user_id', referencedColumnName: 'id' },
-  })
-  likingUser: User[];
+  @OneToMany(() => Heart, (heart) => heart.post)
+  hearts: Heart[];
 
   @OneToMany(() => PostContent, (postContent) => postContent.post)
   postContents: PostContent[];

--- a/back/src/post/entities/post.entity.ts
+++ b/back/src/post/entities/post.entity.ts
@@ -33,8 +33,13 @@ export class Post {
   @JoinColumn({ name: 'habitat_id', referencedColumnName: 'id' })
   habitat: Habitat;
 
-  @OneToMany(() => Heart, (heart) => heart.post)
-  hearts: Heart[];
+  @ManyToMany(() => User, (user) => user.likedPosts)
+  @JoinTable({
+    name: 'heart',
+    joinColumn: { name: 'post_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'user_id', referencedColumnName: 'id' },
+  })
+  likingUsers: User[];
 
   @OneToMany(() => PostContent, (postContent) => postContent.post)
   postContents: PostContent[];

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -17,8 +17,8 @@ export class PostController {
   }
 
   @Get(':habitatId')
-  findAll(@Param('habitatId') habitatId: string, @Query('skip') skip: string, @Query('take') take: string) {
-    return this.postService.findAll(+habitatId, +skip, +take);
+  async findAll(@Param('habitatId') habitatId: string, @Query('lastPostId') lastPostId?: string) {
+    return await this.postService.findAll(+habitatId, lastPostId);
   }
 
   @Get(':habitatId/:id')

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -1,19 +1,19 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query, Req, Res } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, UseInterceptors, UploadedFiles } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
-import { Request, Response } from 'express';
-import { S3Service } from 'src/s3/s3.service';
+import { multerOption, S3Service } from 'src/s3/s3.service';
+import { FilesInterceptor } from '@nestjs/platform-express';
 
 @Controller('post')
 export class PostController {
   constructor(private readonly postService: PostService, private readonly s3Servise: S3Service) {}
 
   @Post()
-  async create(@Req() req: Request, @Res() res: Response, @Body() createPostDto: CreatePostDto) {
-    console.log(createPostDto);
-    const contentsInfos = (await this.s3Servise.uploadS3(req, res)) as any[];
-    return this.postService.create(createPostDto, contentsInfos);
+  @UseInterceptors(FilesInterceptor('upload', 10, multerOption))
+  async uploadFile(@Body() createPostDto: CreatePostDto, @UploadedFiles() files: Express.Multer.File[]) {
+    const contentsInfos = this.s3Servise.getPartialFilesInfo(files);
+    return await this.postService.create(createPostDto, contentsInfos);
   }
 
   @Get(':habitatId')

--- a/back/src/post/post.module.ts
+++ b/back/src/post/post.module.ts
@@ -7,9 +7,10 @@ import { S3Module } from 'src/s3/s3.module';
 import { S3Service } from 'src/s3/s3.service';
 import { PostContent } from 'src/post-contents/entities/post-content.entity';
 import { Content } from 'src/contents/entities/content.entity';
+import { Heart } from 'src/hearts/entities/heart.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, PostContent, Content]), S3Module],
+  imports: [TypeOrmModule.forFeature([Post, PostContent, Content, Heart]), S3Module],
   controllers: [PostController],
   providers: [PostService, S3Service],
 })

--- a/back/src/users/entities/user.entity.ts
+++ b/back/src/users/entities/user.entity.ts
@@ -1,6 +1,7 @@
 import { Comment } from 'src/comment/entities/comment.entity';
 import { Content } from 'src/contents/entities/content.entity';
 import { Habitat } from 'src/habitat/entities/habitat.entity';
+import { Heart } from 'src/hearts/entities/heart.entity';
 import { Post } from 'src/post/entities/post.entity';
 import { Species } from 'src/species/entities/species.entity';
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany, OneToOne, ManyToOne, JoinColumn, ManyToMany } from 'typeorm';
@@ -40,6 +41,6 @@ export class User {
   @JoinColumn({ name: 'habitat_id', referencedColumnName: 'id' })
   habitat: Habitat;
 
-  @ManyToMany(() => Post, (post) => post.likingUser)
-  likedPost: Post[];
+  @OneToMany(() => Heart, (heart) => heart.user)
+  hearts: Heart[];
 }

--- a/back/src/users/entities/user.entity.ts
+++ b/back/src/users/entities/user.entity.ts
@@ -41,6 +41,6 @@ export class User {
   @JoinColumn({ name: 'habitat_id', referencedColumnName: 'id' })
   habitat: Habitat;
 
-  @OneToMany(() => Heart, (heart) => heart.user)
-  hearts: Heart[];
+  @ManyToMany(() => Post, (post) => post.likingUsers)
+  likedPosts: Post[];
 }


### PR DESCRIPTION
### 작업 내역
---
- [x] 게시글 등록 API
- [ ] 게시글 목록 페이징 API
- [x] 좋아요 Entity 설정
- [ ] 게시글 수정 API

### 고민 및 해결
---
게시글 목록 페이징 API를 구현하면서, 해당 게시물을 좋아요 눌렀는 지의 여부를 확인하는 쿼리는 정상적으로 날라갔으나, 응답에는 포함되지 않는 이슈를 만나 6시간동안 고군분투했으나 결국 고치지 못하였다. `getMany()`로 받아올 때는 안 보이지만, `getRawMany()`로 받아올 때 보여지지만, 페이징과 select 기능이 작동하지 않는다. 
그래서 임시로 'hearts' path로 요청하면 좋아요 여부를 받을 수 있게 조치해놨다.
많은 시간을 투자했으나 건진건 딱히 없네요.. 너무 죄송합니다.

### (필요시) 데모 이미지
---

- getMany()로 응답했을 때
페이징 응답을 보낼 때, 마지막 포스트의 아이디를 반환한다. 여기서 isHeart가 보이지 않음을 확인할 수 있다.
![image](https://user-images.githubusercontent.com/58130501/141191442-f4583bd9-f882-4fa0-ac87-342e031dadd4.png)

- getRawMany()로 응답했을 때
여기선 isHeart가 보이지만, 페이징이 적용되지 않는다.
select를 적용하면 isHeart가 안 보이고, select를 적용하지 않으면 유저의 비밀번호가 노출된다.
![image](https://user-images.githubusercontent.com/58130501/141192948-d4949a0f-3f13-45ce-9522-b388669fc51f.png)

좋아요를 누른 게시물
![image](https://user-images.githubusercontent.com/58130501/141193720-65c72926-907f-415e-9f30-1975c57f8f78.png)


좋아요를 안 누른 게시물
![image](https://user-images.githubusercontent.com/58130501/141193750-36899e1a-491c-4112-a630-b2db4c5e4b42.png)

