### PR TITLE
[W3][D4][다람이] 글 상세보기 캐러셀 및 swipebox 구현

### DIFF
--- a/front/src/components/DetailModal/DetailModal.tsx
+++ b/front/src/components/DetailModal/DetailModal.tsx
@@ -1,0 +1,56 @@
+import React, { useRef } from 'react';
+import styled from 'styled-components';
+import { flexBox } from '../../lib/styles/mixin';
+import { Palette } from '../../lib/styles/Palette';
+import Carousel from '../_common/Carousel/Carousel';
+import PreviewBox from './PreviewBox';
+import { ToggleHandler } from '../_common/Modal/useModal';
+
+interface DetailModalProps {
+  hide: ToggleHandler;
+  imageURLs: string[];
+}
+
+const DetailModalDiv = styled.div`
+  ${flexBox()};
+  width: 80vw;
+  height: 80vh;
+  background: ${Palette.WHITE};
+  box-shadow: 0 4px 10px rgba(51, 51, 51, 1), 0 0 4px rgba(51, 51, 51, 0.5);
+  border-radius: 10px;
+  min-height: 500px;
+`;
+
+const ContentsDiv = styled.div`
+  width: 50%;
+  height: 100%;
+`;
+
+const MainContentsDiv = styled.div`
+  width: 70%;
+  height: 50%;
+  margin: auto;
+  transform: translateY(30%);
+`;
+
+const CommunicateDiv = styled.div`
+  width: 50%;
+  height: 100%;
+  background-color: aliceblue;
+`;
+
+const DetailModal = ({ hide, imageURLs }: DetailModalProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <DetailModalDiv ref={ref}>
+      <ContentsDiv>
+        <MainContentsDiv>
+          <Carousel children={<PreviewBox controller={undefined} imageURLs={undefined} />} imageURLs={imageURLs} />
+        </MainContentsDiv>
+      </ContentsDiv>
+      <CommunicateDiv>hi</CommunicateDiv>
+    </DetailModalDiv>
+  );
+};
+
+export default DetailModal;

--- a/front/src/components/DetailModal/PreviewBox.tsx
+++ b/front/src/components/DetailModal/PreviewBox.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+import { CarouselControl } from '../_common/Carousel/Carousel';
+import SwipeBox from '../_common/SwipeBox/SwipeBox';
+
+const PreviewDiv = styled.div`
+  width: 100%;
+  height: 35%;
+  margin-top: 30px;
+  padding: 10px 0;
+  background-color: aliceblue;
+`;
+
+const ImgDiv = styled.div`
+  width: 30%;
+  height: 100%;
+  flex-shrink: 0;
+`;
+
+const PreviewImg = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const PreviewBox = ({ controller, imageURLs }: { controller: CarouselControl | undefined; imageURLs: string[] | undefined }) => {
+  const handleImgClick = (e: React.MouseEvent<HTMLImageElement>) => {
+    const idx = (e.target as HTMLImageElement).dataset.idx;
+    controller?.certainSlide(Number(idx));
+  };
+
+  return (
+    <PreviewDiv>
+      <SwipeBox gap={'10px'} height={'100%'} width={'100%'}>
+        {imageURLs?.map((url, idx) => (
+          <ImgDiv className={'button'} key={(idx.toString() + 'pre' + url).toString()}>
+            <PreviewImg src={url} alt="test" data-idx={idx} onClick={handleImgClick} />
+          </ImgDiv>
+        ))}
+      </SwipeBox>
+    </PreviewDiv>
+  );
+};
+
+export default PreviewBox;

--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -11,6 +11,7 @@ import { useLike } from '../HeartButton/useLike';
 import { makeDropBoxMenu } from '../_common/DropBox/makeDropBoxMenu';
 import Modal from '../_common/Modal/Modal';
 import DeleteModal from '../DeleteModal/DeleteModal';
+import DetailModal from '../DetailModal/DetailModal';
 import useModal from '../_common/Modal/useModal';
 
 const FeedContainerDiv = styled.div`
@@ -66,10 +67,11 @@ export interface FeedProps {
 }
 
 const Feed = ({ nickname, imageURLs, text, lastFeed, scrollRef }: FeedProps) => {
-  const { isShowing, toggle } = useModal();
+  const { isShowing: isDeleteShowing, toggle: toggleDeleteModal } = useModal();
+  const { isShowing: isDetailShowing, toggle: toggleDetailModal } = useModal();
   const [like, toggleLike] = useLike();
 
-  const test = makeDropBoxMenu([{ text: '글 삭제' }, { text: '글 수정', handler: toggle }]);
+  const test = makeDropBoxMenu([{ text: '글 수정' }, { text: '글 삭제', handler: toggleDeleteModal }]);
 
   return (
     <FeedContainerDiv ref={lastFeed}>
@@ -85,13 +87,16 @@ const Feed = ({ nickname, imageURLs, text, lastFeed, scrollRef }: FeedProps) => 
       </FeedContents>
       <FeedInfoDiv>
         <HeartButton like={like} toggleLike={toggleLike} />
-        <CommentBtnSvg />
+        <CommentBtnSvg className={'button'} onClick={toggleDetailModal} />
         <span>13</span>
         <span className="time">2시간 전</span>
       </FeedInfoDiv>
       <FeedTextDiv>{text}</FeedTextDiv>
-      <Modal isShowing={isShowing} hide={toggle}>
-        <DeleteModal hide={toggle} />
+      <Modal isShowing={isDeleteShowing} hide={toggleDeleteModal}>
+        <DeleteModal hide={toggleDeleteModal} />
+      </Modal>
+      <Modal isShowing={isDetailShowing} hide={toggleDetailModal}>
+        <DetailModal imageURLs={imageURLs} hide={toggleDetailModal} />
       </Modal>
     </FeedContainerDiv>
   );

--- a/front/src/components/Feed/FeedScrollBox.tsx
+++ b/front/src/components/Feed/FeedScrollBox.tsx
@@ -60,7 +60,7 @@ const FeedScrollBox = ({ habitat }: { habitat: number }) => {
     const nextFeeds: FeedProps[] = data.map((data) => ({
       id: data.id,
       nickname: data.user.username,
-      imageURLs: [data.urls.raw],
+      imageURLs: [data.urls.raw, data.urls.raw, data.urls.raw, data.urls.raw],
       text: data.description,
     }));
 

--- a/front/src/components/_common/Carousel/Carousel.tsx
+++ b/front/src/components/_common/Carousel/Carousel.tsx
@@ -17,29 +17,41 @@ const CarouselDiv = styled.div`
 
 interface CarouselProps {
   imageURLs: string[];
-  scrollRef: React.MutableRefObject<HTMLDivElement>;
+  scrollRef?: React.MutableRefObject<HTMLDivElement>;
+  children?: React.ReactElement;
 }
 
-const Carousel = ({ imageURLs, scrollRef }: CarouselProps) => {
+export interface CarouselControl {
+  translateStyle: number;
+  slideIndex: number;
+  nextSlide: () => void;
+  prevSlide: () => void;
+  certainSlide: (idx: number) => void;
+}
+
+const Carousel = ({ imageURLs, scrollRef, children }: CarouselProps) => {
   const [rect, ref] = useClientRect();
-  const [translateStyle, slideIndex, nextSlide, prevSlide] = useMoveSlide({ slideCount: imageURLs.length, rect });
+  const [translateStyle, slideIndex, nextSlide, prevSlide, certainSlide] = useMoveSlide({ slideCount: imageURLs.length, rect });
 
   return (
-    <CarouselDiv ref={ref}>
-      <CarouselContents trans={translateStyle} width={rect.width * imageURLs.length}>
-        {imageURLs.map((src, index) => (
-          <Slide key={index} rect={rect} src={src} scrollRef={scrollRef} />
-        ))}
-      </CarouselContents>
+    <>
+      <CarouselDiv ref={ref}>
+        <CarouselContents trans={translateStyle} width={rect.width * imageURLs.length}>
+          {imageURLs.map((src, index) => (
+            <Slide key={index.toString() + 'slide' + src} rect={rect} src={src} scrollRef={scrollRef} />
+          ))}
+        </CarouselContents>
 
-      {imageURLs.length > 1 ? (
-        <>
-          <Arrow direction={'right'} handleClick={nextSlide} />
-          <Arrow direction={'left'} handleClick={prevSlide} />
-          <Dots slides={imageURLs} slideIndex={slideIndex} />
-        </>
-      ) : null}
-    </CarouselDiv>
+        {imageURLs.length > 1 ? (
+          <>
+            <Arrow direction={'right'} handleClick={nextSlide} />
+            <Arrow direction={'left'} handleClick={prevSlide} />
+            <Dots slides={imageURLs} slideIndex={slideIndex} />
+          </>
+        ) : null}
+      </CarouselDiv>
+      {children !== undefined ? React.cloneElement(children, { controller: { translateStyle, slideIndex, nextSlide, prevSlide, certainSlide }, imageURLs: imageURLs }) : null}
+    </>
   );
 };
 

--- a/front/src/components/_common/Carousel/Dots.tsx
+++ b/front/src/components/_common/Carousel/Dots.tsx
@@ -36,7 +36,7 @@ const Dots = ({ slides, slideIndex }: DotsProps) => {
     <DotsDiv>
       <DotsUl>
         {slides.map((v, index) => (
-          <DotLi key={v} active={slideIndex === index} />
+          <DotLi key={index.toString() + 'dot' + v} active={slideIndex === index} />
         ))}
       </DotsUl>
     </DotsDiv>

--- a/front/src/components/_common/Carousel/Slide.tsx
+++ b/front/src/components/_common/Carousel/Slide.tsx
@@ -17,14 +17,14 @@ const Video = styled.video<Pick<SlideProps, 'rect'>>`
 interface SlideProps {
   src: string;
   rect: rectType;
-  scrollRef: React.MutableRefObject<HTMLDivElement>;
+  scrollRef?: React.MutableRefObject<HTMLDivElement>;
 }
 
 const Slide = ({ src, rect, scrollRef }: SlideProps) => {
   const [feedContent, ref] = useGetDiv();
 
   useEffect(() => {
-    if ('id' in feedContent) {
+    if ('id' in feedContent && scrollRef) {
       const observer = new IntersectionObserver(
         (entries) => {
           if (entries[0].isIntersecting) {
@@ -50,7 +50,7 @@ const Slide = ({ src, rect, scrollRef }: SlideProps) => {
           <source src={src} type={'video/mp4'} />
         </Video>
       ) : (
-        <SlideImg src={`default_avatar.png`} data-lazy={src} rect={rect} alt="피드 이미지" />
+        <SlideImg src={scrollRef ? `default_avatar.png` : src} data-lazy={src} rect={rect} alt="피드 이미지" />
       )}
     </div>
   );

--- a/front/src/components/_common/Carousel/useMoveSlide.ts
+++ b/front/src/components/_common/Carousel/useMoveSlide.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { rectType } from '../../../hooks/useClientRect';
 
-type useCarouselType = [number, number, () => void, () => void];
+type useCarouselType = [number, number, () => void, () => void, (idx: number) => void];
 
 interface useCarouselProps {
   slideCount: number;
@@ -30,5 +30,9 @@ export const useMoveSlide = ({ slideCount, rect }: useCarouselProps): useCarouse
     setState({ ...state, slideIndex: slideIndex - 1, translateStyle: (slideIndex - 1) * rect.width });
   };
 
-  return [translateStyle, slideIndex, nextSlide, prevSlide];
+  const certainSlide = (idx: number) => {
+    setState({ ...state, slideIndex: idx, translateStyle: idx * rect.width });
+  };
+
+  return [translateStyle, slideIndex, nextSlide, prevSlide, certainSlide];
 };


### PR DESCRIPTION
### 작업 내역
---
- [x] 캐러셀 기능 확장
- [x] 캐러셀과 반응하는 SwipeBox 구현
- [x] 상세보기 모달 레이아웃 일부 구현

### 고민 및 해결
---
1. 캐러셀에 scrollbox를 할당하지 않으면 lazy loading 하지 않고 그냥 이미지를 불러오도록 할 수 있게함
2. 캐러셀의 인덱스가 한칸씩만 움직일 수 있었는데 어디든지 갈 수 있는 메소드 구현
3. 캐러셀의 컨트롤을 담당하는 훅을 캐러셀의 자식에게 내려줄 수 있도록 함
4. 캐러셀 내부에서 배열 map으로 만든 앨리먼트들의 key 값을 인덱스로 해서 key값 중복 애러가 나는 것을 임시방편으로 해결해두엇음. 

### (필요시) 데모 이미지
---
![demo](https://user-images.githubusercontent.com/63776725/141279238-bb25ddc9-2d04-42cb-88c9-e965e169e530.gif)
