### PR TITLE
[W4][D1][뚱이] Post API 쿼리 개선, 리팩토링

### DIFF
--- a/back/src/contents/entities/content.entity.ts
+++ b/back/src/contents/entities/content.entity.ts
@@ -1,6 +1,11 @@
 import { PostContent } from 'src/post-contents/entities/post-content.entity';
 import { User } from 'src/users/entities/user.entity';
-import { Entity, Column, PrimaryGeneratedColumn, OneToOne } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToOne,
+} from 'typeorm';
 
 @Entity({ name: 'contents' })
 export class Content {

--- a/back/src/post-contents/entities/post-content.entity.ts
+++ b/back/src/post-contents/entities/post-content.entity.ts
@@ -20,7 +20,9 @@ export class PostContent {
   @JoinColumn({ name: 'post_id', referencedColumnName: 'id' })
   post: Post;
 
-  @OneToOne(() => Content, (content) => content.postContent)
+  @OneToOne(() => Content, (content) => content.postContent, {
+    cascade: ['insert'],
+  })
   @JoinColumn({ name: 'contents_id', referencedColumnName: 'id' })
   content: Content;
 }

--- a/back/src/post/dto/patchPostRequestDto.ts
+++ b/back/src/post/dto/patchPostRequestDto.ts
@@ -1,5 +1,5 @@
 export class PatchPostRequestDto {
-  contentInfos: string;
+  contentIds: string;
   humanContent: string;
   animalContent: string;
 }

--- a/back/src/post/entities/post.entity.ts
+++ b/back/src/post/entities/post.entity.ts
@@ -54,7 +54,9 @@ export class Post {
   })
   likingUsers: User[];
 
-  @OneToMany(() => PostContent, (postContent) => postContent.post)
+  @OneToMany(() => PostContent, (postContent) => postContent.post, {
+    cascade: ['insert'],
+  })
   postContents: PostContent[];
 
   @OneToMany(() => Comment, (comment) => comment.post)

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -12,7 +12,6 @@ import {
 } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
-import { UpdatePostDto } from './dto/update-post.dto';
 import { getPartialFilesInfo } from 'utils/s3.util';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { PatchPostRequestDto } from './dto/patchPostRequestDto';
@@ -38,14 +37,9 @@ export class PostController {
   @Get(':habitatId')
   async findAll(
     @Param('habitatId') habitatId: string,
-    @Query('userId') userId: string,
     @Query('lastPostId') lastPostId?: string
   ) {
-    return await this.postService.findAll(
-      +habitatId,
-      +userId,
-      +lastPostId
-    );
+    return await this.postService.findAll(+habitatId, +lastPostId);
   }
 
   @Get(':habitatId/:id')

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -53,20 +53,20 @@ export class PostController {
     return this.postService.findOne(+id);
   }
 
-  @Patch(':id')
-  @UseInterceptors(FilesInterceptor('upload', 10, multerOption))
-  update(
-    @Param('id') id: string,
-    @Body() patchPostRequestDto: PatchPostRequestDto,
-    @UploadedFiles() files: Express.Multer.File[]
-  ) {
-    const contentsInfos = getPartialFilesInfo(files);
-    return this.postService.update(
-      +id,
-      patchPostRequestDto,
-      contentsInfos
-    );
-  }
+  // @Patch(':id')
+  // @UseInterceptors(FilesInterceptor('upload', 10, multerOption))
+  // update(
+  //   @Param('id') id: string,
+  //   @Body() patchPostRequestDto: PatchPostRequestDto,
+  //   @UploadedFiles() files: Express.Multer.File[]
+  // ) {
+  //   const contentsInfos = getPartialFilesInfo(files);
+  //   return this.postService.update(
+  //     +id,
+  //     patchPostRequestDto,
+  //     contentsInfos
+  //   );
+  // }
 
   @Delete(':id')
   remove(@Param('id') id: string) {

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -53,20 +53,20 @@ export class PostController {
     return this.postService.findOne(+id);
   }
 
-  // @Patch(':id')
-  // @UseInterceptors(FilesInterceptor('upload', 10, multerOption))
-  // update(
-  //   @Param('id') id: string,
-  //   @Body() patchPostRequestDto: PatchPostRequestDto,
-  //   @UploadedFiles() files: Express.Multer.File[]
-  // ) {
-  //   const contentsInfos = getPartialFilesInfo(files);
-  //   return this.postService.update(
-  //     +id,
-  //     patchPostRequestDto,
-  //     contentsInfos
-  //   );
-  // }
+  @Patch(':id')
+  @UseInterceptors(FilesInterceptor('upload', 10, multerOption))
+  async update(
+    @Param('id') id: string,
+    @Body() patchPostRequestDto: PatchPostRequestDto,
+    @UploadedFiles() files: Express.Multer.File[]
+  ) {
+    const contentsInfos = getPartialFilesInfo(files);
+    return await this.postService.update(
+      +id,
+      patchPostRequestDto,
+      contentsInfos
+    );
+  }
 
   @Delete(':id')
   remove(@Param('id') id: string) {

--- a/back/src/post/post.module.ts
+++ b/back/src/post/post.module.ts
@@ -6,11 +6,10 @@ import { Post } from './entities/post.entity';
 import { PostContent } from 'src/post-contents/entities/post-content.entity';
 import { Content } from 'src/contents/entities/content.entity';
 import { Heart } from 'src/hearts/entities/heart.entity';
+import { PostRepository } from './post.repository';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Post, PostContent, Content, Heart]),
-  ],
+  imports: [TypeOrmModule.forFeature([PostRepository])],
   controllers: [PostController],
   providers: [PostService],
 })

--- a/back/src/post/post.repository.ts
+++ b/back/src/post/post.repository.ts
@@ -1,0 +1,32 @@
+import { CreateContentDto } from 'src/contents/dto/create-content.dto';
+import { Content } from 'src/contents/entities/content.entity';
+import { PostContent } from 'src/post-contents/entities/post-content.entity';
+import { EntityRepository, Repository } from 'typeorm';
+import { CreatePostDto } from './dto/create-post.dto';
+import { Post } from './entities/post.entity';
+
+@EntityRepository(Post)
+export class PostRepository extends Repository<Post> {
+  async createPost(
+    createPostDto: CreatePostDto,
+    contentsInfos: CreateContentDto[]
+  ): Promise<Post> {
+    const post = new Post();
+    post.animalContent = createPostDto.animalContent;
+    post.humanContent = createPostDto.humanContent;
+    post.userId = createPostDto.userId;
+    post.habitatId = createPostDto.habitatId;
+
+    const postContents = contentsInfos.map((contentsInfo, i) => {
+      const content = new Content();
+      content.url = contentsInfo.url;
+      content.mimeType = contentsInfo.mimeType;
+      const postContent = new PostContent();
+      postContent.content = content;
+      return postContent;
+    });
+    post.postContents = postContents;
+
+    return await this.save(post);
+  }
+}

--- a/back/src/post/post.service.ts
+++ b/back/src/post/post.service.ts
@@ -29,24 +29,22 @@ export class PostService {
     createPostDto: CreatePostDto,
     contentsInfos: CreateContentDto[]
   ) {
-    const newPost = this.postRepository.create(createPostDto);
-    const newPostEntity = await this.postRepository.save(newPost);
-
-    const newContents = contentsInfos.map((contentsInfo, i) => {
-      return this.contentRepository.create(contentsInfo);
+    let post = new Post();
+    post.animalContent = createPostDto.animalContent;
+    post.humanContent = createPostDto.humanContent;
+    post.userId = createPostDto.userId;
+    post.habitatId = createPostDto.habitatId;
+    const postContents = contentsInfos.map((contentsInfo, i) => {
+      const content = new Content();
+      content.url = contentsInfo.url;
+      content.mimeType = contentsInfo.mimeType;
+      const postContent = new PostContent();
+      postContent.content = content;
+      return postContent;
     });
-    const newContentsEntities = await this.contentRepository.save(
-      newContents
-    );
-
-    newContentsEntities.forEach((newContentsEntity, i) => {
-      const newPostContent = this.postContentRepository.create({
-        postId: newPostEntity.id,
-        contentsId: newContentsEntity.id,
-      });
-      this.postContentRepository.save(newPostContent);
-    });
-    return newPostEntity;
+    post.postContents = postContents;
+    post = await this.postRepository.save(post);
+    return post;
   }
 
   async getFirstPage(habitatId: number, userId: number) {


### PR DESCRIPTION
### 작업 내역
---
- [x] API Pagination 수정
- [x] API update 수정
- [x] API create 수정

### 고민 및 해결
---
서비스의 메소드가 하나의 트랜잭션 단위로 실행될 수 있도록 수정함. 이 과정에서 tyorm 코드를 어떤식으로 짜야할지 고민함.
간단한 것은 되도록 Entity의 relation을 이용한다. 
entity의 relation을 이용해도 안 된다면 Connection인스턴스의 queryRunner를 사용하여 트랜잭션 단위로 관리한다.
쿼리 성능 개선이 필요한 것은 raw query로 하면 좋다.

이것저것 찾아보다가 알게된 것
- onetoone 관계는 ondelete가 먹히지 않는다.
- onetotwo 관계의 프로퍼티가 있을 때, update 메소드가 작동하지 않는다.
- typeorm은 아직 충분한 기능을 지원하지 못하는 것 같다.

제약관계를 수정한 것:
- post_contents_contents_fk의 on delete no action -> on delete cascade 로 변경
- 다른 제약관계도 바꿔야할 필요가 있다.

### (필요시) 데모 이미지
---

업데이트 중반 쿼리문
![image](https://user-images.githubusercontent.com/58130501/141843667-208cd978-1a82-47ff-a4d4-7162c23f0139.png)

제일 최근 쿼리문
![image](https://user-images.githubusercontent.com/58130501/141843692-89c1bb87-f6a4-4e77-b16c-255944570f8e.png)

contents의 insert문이 여러 개 날라가는 것을 볼 수 있는데, 삽입된 contents의 id값을 얻으려면 어쩔 수 없는 것으로 생각된다.

변경된 Get /posts/:habitatId API 결과

![image](https://user-images.githubusercontent.com/58130501/141844151-99adc835-189d-4935-81cb-9bb45fb5a29e.png)
![image](https://user-images.githubusercontent.com/58130501/141844096-df8397e2-43f2-4531-927c-e397062371cf.png)
