### PR TITLE
[W4][D2][징징이] 회원가입 페이지 구현 및 연동

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -11,11 +11,13 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@types/react-transition-group": "^4.4.4",
     "craco-alias": "^3.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-transition-group": "^4.4.2",
     "styled-components": "^5.3.3",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"

--- a/front/src/components/Button/Button.tsx
+++ b/front/src/components/Button/Button.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import { Palette } from '@lib/styles/Palette';
+
+interface ButtonProps {
+  borderColor?: string;
+}
+
+const Button = styled.button<ButtonProps>`
+  width: 100px;
+  height: 45px;
+  color: black;
+  border: 1px solid ${({ borderColor }) => (borderColor ? borderColor : Palette.ACTIVE)};
+  background: none;
+  border-radius: 8px;
+  transition: 0.5s ease all;
+  &.active {
+    color: white;
+    background: ${Palette.ACTIVE};
+  }
+`;
+
+export default Button;

--- a/front/src/components/Header/UserInfo.tsx
+++ b/front/src/components/Header/UserInfo.tsx
@@ -9,6 +9,7 @@ import { makeDropBoxMenu } from '@common/DropBox/makeDropBoxMenu';
 import { flexBox } from '@lib/styles/mixin';
 import { ReactComponent as HamburgerMenuSvg } from '@assets/icons/hamburger_menu.svg';
 import MagicNumber from '@src/lib/styles/magic';
+import { useHistory } from 'react-router-dom';
 
 const UserInfoBlock = styled.div`
   ${flexBox('center', 'center')}
@@ -23,8 +24,15 @@ interface UserInfoProps {
 }
 
 const UserInfo = ({ username = '핑핑이' }: UserInfoProps) => {
+  const history = useHistory();
   const { isShowing, toggle } = useModal();
-  const dropboxMenu = makeDropBoxMenu([{ text: '로그인', handler: toggle }, { text: '회원가입' }]);
+
+  const moveRegisterPage = () => history.push('/register');
+
+  const dropboxMenu = makeDropBoxMenu([
+    { text: '로그인', handler: toggle },
+    { text: '회원가입', handler: moveRegisterPage },
+  ]);
   return (
     <UserInfoBlock>
       <div className={'username'}>{username}</div>

--- a/front/src/components/LoginModal/LoginModal.tsx
+++ b/front/src/components/LoginModal/LoginModal.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { flexBox, boxShadow } from '@lib/styles/mixin';
 import { Palette } from '@lib/styles/Palette';
 import { ToggleHandler } from '@common/Modal/useModal';
+import { useHistory } from 'react-router-dom';
 
 const LoginDiv = styled.div`
   ${flexBox('center', 'center', 'column')};
@@ -63,6 +64,12 @@ const AuthBtn = styled(DefaultBtn)`
 `;
 
 const LoginModal = ({ hide }: { hide: ToggleHandler }) => {
+  const history = useHistory();
+
+  const handleClick = () => {
+    history.push('/register');
+  };
+
   return (
     <LoginDiv>
       <LoginForm>
@@ -80,7 +87,9 @@ const LoginModal = ({ hide }: { hide: ToggleHandler }) => {
         </LoginBtnDiv>
       </LoginForm>
       <AuthBtnDiv>
-        <AuthBtn color={Palette.GREEN}>회원가입</AuthBtn>
+        <AuthBtn onClick={handleClick} color={Palette.GREEN}>
+          회원가입
+        </AuthBtn>
       </AuthBtnDiv>
     </LoginDiv>
   );

--- a/front/src/components/Register/AccountInfo.tsx
+++ b/front/src/components/Register/AccountInfo.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import { flexBox } from '@lib/styles/mixin';
+import Input from '@common/Input/Input';
+import { UserData } from '@components/Register/Register';
+import { ErrorType } from '@hooks/useForm';
+import Button from '@components/Button/Button';
+
+const AccountInfoBlock = styled.div`
+  position: absolute;
+  padding: 0 40px;
+`;
+
+const Header = styled.div`
+  ${flexBox('space-between', 'flex-start', 'column')};
+  .logo {
+    font-size: 18px;
+  }
+  .title {
+    margin: 15px 0;
+    font-size: 24px;
+  }
+`;
+
+const Form = styled.form`
+  ${flexBox('center', 'center', 'column')};
+
+  & > * {
+    margin: 20px;
+  }
+`;
+
+interface AccountInfoProps {
+  values: UserData;
+  handleChange: React.ChangeEventHandler<HTMLInputElement>;
+  errors: ErrorType<UserData>;
+  flag: boolean;
+  handleAccountClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const AccountInfo = ({ values, handleChange, errors, flag, handleAccountClick }: AccountInfoProps) => {
+  const { id, password, passwordConfirm } = values;
+
+  return (
+    <AccountInfoBlock>
+      <Header>
+        <div className={'logo'}>핑핑이와 친구들</div>
+        <div className={'title'}>계정 만들기</div>
+      </Header>
+      <Form>
+        <Input name={'id'} placeholder={'아이디'} value={id} handleChange={handleChange} errorMessage={errors.id} />
+        <Input name={'password'} type={'password'} placeholder={'비밀번호'} value={password} handleChange={handleChange} errorMessage={errors.password} />
+        <Input name={'passwordConfirm'} type={'password'} placeholder={'비밀번호 확인'} value={passwordConfirm} handleChange={handleChange} errorMessage={errors.passwordConfirm} />
+        <Button className={`${flag && 'active'}`} onClick={handleAccountClick}>
+          다음
+        </Button>
+      </Form>
+    </AccountInfoBlock>
+  );
+};
+
+export default AccountInfo;

--- a/front/src/components/Register/AccountInfo.tsx
+++ b/front/src/components/Register/AccountInfo.tsx
@@ -6,6 +6,42 @@ import { UserData } from '@components/Register/Register';
 import { ErrorType } from '@hooks/useForm';
 import Button from '@components/Button/Button';
 
+interface AccountInfoProps {
+  values: UserData;
+  handleChange: React.ChangeEventHandler<HTMLInputElement>;
+  errors: ErrorType<UserData>;
+  flag: boolean;
+  handleAccountClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const AccountInfo = ({ values, handleChange, errors, flag, handleAccountClick }: AccountInfoProps) => {
+  const { id, password, passwordConfirm } = values;
+
+  return (
+    <AccountInfoBlock>
+      <Header>
+        <div className={'logo'}>핑핑이와 친구들</div>
+        <div className={'title'}>계정 만들기</div>
+      </Header>
+      <Form>
+        <Input name={'id'} placeholder={'아이디'} value={id} handleChange={handleChange} errorMessage={errors.id} />
+        <Input name={'password'} type={'password'} placeholder={'비밀번호'} value={password} handleChange={handleChange} errorMessage={errors.password} />
+        <Input name={'passwordConfirm'} type={'password'} placeholder={'비밀번호 확인'} value={passwordConfirm} handleChange={handleChange} errorMessage={errors.passwordConfirm} />
+        <ButtonContainer>
+          <Button borderColor={'none'} onClick={handleAccountClick}>
+            뒤로 가기
+          </Button>
+          <Button className={`${flag && 'active'}`} onClick={handleAccountClick}>
+            다음
+          </Button>
+        </ButtonContainer>
+      </Form>
+    </AccountInfoBlock>
+  );
+};
+
+export default AccountInfo;
+
 const AccountInfoBlock = styled.div`
   position: absolute;
   padding: 0 40px;
@@ -29,34 +65,7 @@ const Form = styled.form`
     margin: 20px;
   }
 `;
-
-interface AccountInfoProps {
-  values: UserData;
-  handleChange: React.ChangeEventHandler<HTMLInputElement>;
-  errors: ErrorType<UserData>;
-  flag: boolean;
-  handleAccountClick: React.MouseEventHandler<HTMLButtonElement>;
-}
-
-const AccountInfo = ({ values, handleChange, errors, flag, handleAccountClick }: AccountInfoProps) => {
-  const { id, password, passwordConfirm } = values;
-
-  return (
-    <AccountInfoBlock>
-      <Header>
-        <div className={'logo'}>핑핑이와 친구들</div>
-        <div className={'title'}>계정 만들기</div>
-      </Header>
-      <Form>
-        <Input name={'id'} placeholder={'아이디'} value={id} handleChange={handleChange} errorMessage={errors.id} />
-        <Input name={'password'} type={'password'} placeholder={'비밀번호'} value={password} handleChange={handleChange} errorMessage={errors.password} />
-        <Input name={'passwordConfirm'} type={'password'} placeholder={'비밀번호 확인'} value={passwordConfirm} handleChange={handleChange} errorMessage={errors.passwordConfirm} />
-        <Button className={`${flag && 'active'}`} onClick={handleAccountClick}>
-          다음
-        </Button>
-      </Form>
-    </AccountInfoBlock>
-  );
-};
-
-export default AccountInfo;
+const ButtonContainer = styled.div`
+  ${flexBox('space-between', 'center')};
+  width: 100%;
+`;

--- a/front/src/components/Register/MoreInfo.tsx
+++ b/front/src/components/Register/MoreInfo.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components';
+import { flexBox } from '@lib/styles/mixin';
+import Input from '@common/Input/Input';
+import { InfoData } from '@components/Register/Register';
+import { ErrorType } from '@hooks/useForm';
+import Select from '@common/Select/Select';
+import Button from '@components/Button/Button';
+
+interface MoreInfoProps {
+  values: InfoData;
+  handleChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement>;
+  errors: ErrorType<InfoData>;
+  flag: boolean;
+  handleMoreInfoClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const habitatOptions = ['강남역 뒷골목', '부산 해운대', '서울숲'];
+const animalOptions = ['고양이', '강아지', '돌멩이'];
+
+const MoreInfo = ({ values, flag, handleMoreInfoClick, errors, handleChange }: MoreInfoProps) => {
+  const { username } = values;
+
+  return (
+    <MoreInfoBlock>
+      <Header>
+        <div className={'logo'}>핑핑이와 친구들</div>
+        <div className={'title'}>추가 정보 입력하기</div>
+      </Header>
+      <Form>
+        <Input name={'username'} placeholder={'유저 아이디'} value={username} handleChange={handleChange} errorMessage={errors.username} />
+        <Select name={'habitat'} id={'habitat'} options={habitatOptions} label={'서식지'} handleChange={handleChange} />
+        <Select name={'category'} id={'category'} options={animalOptions} label={'동물 카테고리'} handleChange={handleChange} />
+        <ButtonContainer>
+          <Button borderColor={'none'} onClick={handleMoreInfoClick}>
+            뒤로 가기
+          </Button>
+          <Button className={`${flag && 'active'}`} onClick={handleMoreInfoClick}>
+            가입
+          </Button>
+        </ButtonContainer>
+      </Form>
+    </MoreInfoBlock>
+  );
+};
+
+export default MoreInfo;
+
+const MoreInfoBlock = styled.div`
+  position: absolute;
+  padding: 0 40px;
+  width: 370px;
+  height: 420px;
+`;
+const Header = styled.div`
+  ${flexBox('space-between', 'flex-start', 'column')};
+  .logo {
+    font-size: 18px;
+  }
+  .title {
+    margin: 15px 0;
+    font-size: 24px;
+  }
+`;
+const Form = styled.form`
+  ${flexBox('center', 'center', 'column')};
+
+  & > * {
+    margin: 20px;
+  }
+`;
+const ButtonContainer = styled.div`
+  ${flexBox('space-between', 'center')};
+  width: 100%;
+`;

--- a/front/src/components/Register/Register.tsx
+++ b/front/src/components/Register/Register.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import styled from 'styled-components';
+import AccountInfo from '@components/Register/AccountInfo';
+import { Route, RouteComponentProps, Switch, withRouter } from 'react-router-dom';
+import MoreInfo from '@components/Register/MoreInfo';
+import useForm, { Validations } from '@hooks/useForm';
+import { TransitionGroup, CSSTransition } from 'react-transition-group';
+import './Transition.css';
+import usePageSlide from '@hooks/usePageSlide';
+
+const RegisterDiv = styled.div`
+  position: relative;
+  width: 450px;
+  height: 500px;
+  border: 1px solid #bebbbb;
+  padding: 40px;
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+export interface UserData {
+  id: string;
+  password: string;
+  passwordConfirm: string;
+}
+const initialUserData = {
+  id: '',
+  password: '',
+  passwordConfirm: '',
+};
+export interface InfoData {
+  username: string;
+  habitat: string;
+  category: string;
+}
+const initialInfoData = {
+  username: '',
+  habitat: '강남역 뒷골목',
+  category: '고양이',
+};
+const userDataValidations: Validations<UserData> = [
+  { value: 'id', check: (values) => values['id'].length <= 4, message: '아이디는 4자를 넘어야합니다.' },
+  { value: 'id', check: (values) => values['id'].length === 0, message: '아이디를 입력하세요.' },
+  { value: 'password', check: (values) => values['password'].length < 8, message: '비밀번호는 8자 이상이어야합니다.' },
+  { value: 'password', check: (values) => values['password'].length === 0, message: '비밀번호를 입력하세요.' },
+  { value: 'passwordConfirm', check: (values) => values['passwordConfirm'] !== values['password'], message: '입력하신 비밀번호와 일치하지 않습니다' },
+];
+
+const infoDataValidations: Validations<InfoData> = [{ value: 'username', check: (values) => values['username'].length <= 4, message: '아이디는 4자를 넘어야합니다.' }];
+
+interface RegisterProps extends RouteComponentProps {}
+
+const Register = ({ location }: RegisterProps) => {
+  const { values: accountValues, handleChange: handleAccountChange, errors: accountErrors, flag: accountFlag } = useForm<UserData>(initialUserData, userDataValidations);
+  const { values: moreInfoValues, handleChange: handleMoreInfoChange, errors: moreInfoErrors, flag: moreInfoFlag } = useForm<InfoData>(initialInfoData, infoDataValidations);
+  const { direction, handleAccountClick, handleMoreInfoClick } = usePageSlide(accountFlag, moreInfoFlag);
+
+  return (
+    <RegisterDiv>
+      <TransitionGroup className={'transition-group'}>
+        <CSSTransition key={location.pathname} classNames={direction} timeout={500}>
+          <Switch location={location}>
+            <Route path="/register/more-info">
+              <MoreInfo values={moreInfoValues} handleChange={handleMoreInfoChange} errors={moreInfoErrors} flag={moreInfoFlag} handleMoreInfoClick={handleMoreInfoClick} />
+            </Route>
+            <Route path="/register">
+              <AccountInfo values={accountValues} handleChange={handleAccountChange} errors={accountErrors} flag={accountFlag} handleAccountClick={handleAccountClick} />
+            </Route>
+          </Switch>
+        </CSSTransition>
+      </TransitionGroup>
+    </RegisterDiv>
+  );
+};
+
+export default withRouter(Register);

--- a/front/src/components/Register/Transition.css
+++ b/front/src/components/Register/Transition.css
@@ -1,0 +1,47 @@
+.transition-group {
+    position: relative;
+}
+
+.right-enter {
+    opacity: 0;
+    transform: translateX(450px);
+}
+
+.right-enter-active {
+    opacity: 1;
+    transform: translateX(0);
+    transition: all 0.5s ease-in;
+}
+
+.right-exit {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.right-exit-active {
+    opacity: 0;
+    transform: translateX(-450px);
+    transition: all 0.5s ease-in;
+}
+
+.left-enter {
+    opacity: 0;
+    transform: translateX(-450px);
+}
+
+.left-enter-active {
+    opacity: 1;
+    transform: translateX(0);
+    transition: all 0.5s ease-in;
+}
+
+.left-exit {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.left-exit-active {
+    opacity: 0;
+    transform: translateX(450px);
+    transition: all 0.5s ease-in;
+}

--- a/front/src/components/_common/Input/Input.tsx
+++ b/front/src/components/_common/Input/Input.tsx
@@ -41,7 +41,7 @@ const ErrorMessageDiv = styled.div`
 
 interface InputProps {
   placeholder: string;
-  value: string;
+  value?: string;
   name: string;
   handleChange?: React.ChangeEventHandler<HTMLInputElement>;
   type?: 'text' | 'password';

--- a/front/src/components/_common/Input/Input.tsx
+++ b/front/src/components/_common/Input/Input.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Palette } from '@lib/styles/Palette';
+
+const InputContainer = styled.div`
+  position: relative;
+  width: 250px;
+  height: 45px;
+`;
+
+const StyledInput = styled.input<{ error: string }>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  padding: 16px 18px 0;
+  font-size: 18px;
+  border: 1px solid ${(props) => (props.error ? Palette.RED : '')};
+  border-radius: 8px;
+  &:focus + div {
+    transform: translate(19px, 2px) scale(0.8);
+    color: ${Palette.ACTIVE};
+  }
+  &:not(:focus):valid + div {
+    transform: translate(19px, 2px) scale(0.8);
+  }
+`;
+
+const StyledPlaceHolderDiv = styled.div`
+  position: absolute;
+  color: ${Palette.GRAY};
+  transform: translate(18px, 15px);
+  transition: 0.2s ease all;
+`;
+
+const ErrorMessageDiv = styled.div`
+  position: absolute;
+  font-size: 12px;
+  transform: translate(10px, 50px);
+  color: ${Palette.RED};
+`;
+
+interface InputProps {
+  placeholder: string;
+  value: string;
+  name: string;
+  handleChange?: React.ChangeEventHandler<HTMLInputElement>;
+  type?: 'text' | 'password';
+  errorMessage?: string;
+}
+
+const Input = ({ type = 'text', placeholder, value, handleChange, name, errorMessage }: InputProps) => {
+  const [error, setError] = useState('');
+  const handleBlur = () => {
+    setError(errorMessage!);
+  };
+  return (
+    <InputContainer>
+      <StyledInput error={error} name={name} type={type} required value={value} onChange={handleChange} onBlur={handleBlur} />
+      <StyledPlaceHolderDiv>{placeholder}</StyledPlaceHolderDiv>
+      <ErrorMessageDiv>{error}</ErrorMessageDiv>
+    </InputContainer>
+  );
+};
+
+export default Input;

--- a/front/src/components/_common/Select/Select.tsx
+++ b/front/src/components/_common/Select/Select.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledLabel = styled.label`
+  margin-top: 5px;
+
+  .label-text {
+    font-size: 14px;
+    margin: 0 0 5px 5px;
+  }
+`;
+
+const StyledSelect = styled.select`
+  width: 250px;
+  height: 45px;
+  border-radius: 8px;
+  padding-left: 18px;
+  border: 1px solid black;
+  font-size: 16px;
+  .select-holder {
+    color: #5b5759;
+  }
+`;
+interface SelectProps {
+  name: string;
+  id: string;
+  options: string[];
+  label?: string;
+  handleChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement>;
+}
+
+const Select = ({ options, name, id, label, handleChange }: SelectProps) => {
+  return (
+    <StyledLabel htmlFor={id}>
+      <div className={'label-text'}>{label}</div>
+      <StyledSelect name={name} id={id} onChange={handleChange}>
+        <option disabled>{label} 선택</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </StyledSelect>
+    </StyledLabel>
+  );
+};
+
+export default Select;

--- a/front/src/hooks/useForm.ts
+++ b/front/src/hooks/useForm.ts
@@ -1,0 +1,38 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+
+interface Validation<T> {
+  value: keyof T;
+  check: (values: T) => boolean;
+  message: string;
+}
+
+export type Validations<T> = Validation<T>[];
+type ErrorType<T> = Partial<Record<keyof T, string>>;
+
+const useForm = <T>(initialValues: T, validations: Validations<T>) => {
+  const [flag, setFlag] = useState(false);
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState<ErrorType<T>>({});
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setValues({ ...values, [e.target.name]: e.target.value });
+  };
+
+  useEffect(() => {
+    const nextError: ErrorType<T> = {};
+    validations
+      .filter((validation) => validation.check(values))
+      .forEach((validation) => {
+        nextError[validation.value] = validation.message;
+      });
+    setErrors(nextError);
+  }, [values]);
+
+  useEffect(() => {
+    setFlag(!Object.keys(errors).length);
+  }, [errors]);
+
+  return { values, handleChange, errors, flag };
+};
+
+export default useForm;

--- a/front/src/hooks/useForm.ts
+++ b/front/src/hooks/useForm.ts
@@ -7,14 +7,14 @@ interface Validation<T> {
 }
 
 export type Validations<T> = Validation<T>[];
-type ErrorType<T> = Partial<Record<keyof T, string>>;
+export type ErrorType<T> = Partial<Record<keyof T, string>>;
 
 const useForm = <T>(initialValues: T, validations: Validations<T>) => {
   const [flag, setFlag] = useState(false);
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState<ErrorType<T>>({});
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     setValues({ ...values, [e.target.name]: e.target.value });
   };
 

--- a/front/src/hooks/usePageSlide.ts
+++ b/front/src/hooks/usePageSlide.ts
@@ -1,0 +1,50 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+type SlideDirection = 'right' | 'left' | '';
+
+const usePageSlide = (accountFlag: boolean, moreInfoFlag: boolean) => {
+  const history = useHistory();
+  const location = useLocation();
+  const [direction, setDirection] = useState<SlideDirection>('');
+
+  const handleAccountClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (accountFlag) {
+      setDirection('right');
+    }
+  };
+
+  const handleMoreInfoClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    const target = e.target as HTMLButtonElement;
+    if (target.innerHTML === '뒤로 가기') {
+      setDirection('left');
+      return;
+    }
+    if (target.innerHTML === '가입' && moreInfoFlag) {
+      // todo: something
+      return;
+    }
+  };
+
+  const movePage = useCallback(() => {
+    if (direction === 'right') {
+      history.push(`${location.pathname}/more-info`);
+      return;
+    }
+    if (direction === 'left') {
+      history.goBack();
+      return;
+    }
+  }, [history, direction]);
+
+  useEffect(() => {
+    //todo: 추상화를 권유하셔서 해봤는데 이렇게 하는게 맞을까..?
+    movePage();
+  }, [movePage]);
+
+  return { direction, handleAccountClick, handleMoreInfoClick };
+};
+
+export default usePageSlide;

--- a/front/src/hooks/usePageSlide.ts
+++ b/front/src/hooks/usePageSlide.ts
@@ -1,6 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
+const TEXT = {
+  NEXT: '다음',
+  BACK: '뒤로 가기',
+  REGISTER: '가입',
+};
 type SlideDirection = 'right' | 'left' | '';
 
 const usePageSlide = (accountFlag: boolean, moreInfoFlag: boolean) => {
@@ -10,19 +15,23 @@ const usePageSlide = (accountFlag: boolean, moreInfoFlag: boolean) => {
 
   const handleAccountClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (accountFlag) {
+    const target = e.target as HTMLButtonElement;
+
+    if (target.innerHTML === TEXT.NEXT && accountFlag) {
       setDirection('right');
+      return;
     }
+    history.goBack();
   };
 
   const handleMoreInfoClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     const target = e.target as HTMLButtonElement;
-    if (target.innerHTML === '뒤로 가기') {
+    if (target.innerHTML === TEXT.BACK) {
       setDirection('left');
       return;
     }
-    if (target.innerHTML === '가입' && moreInfoFlag) {
+    if (target.innerHTML === TEXT.REGISTER && moreInfoFlag) {
       // todo: something
       return;
     }

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -4,10 +4,8 @@ import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 ReactDOM.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>,
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
   document.getElementById('root')
 );

--- a/front/src/pages/RegisterPage.tsx
+++ b/front/src/pages/RegisterPage.tsx
@@ -1,7 +1,20 @@
 import React from 'react';
+import styled from 'styled-components';
+import Register from '@components/Register/Register';
+import { flexBox } from '@lib/styles/mixin';
+
+const RegisterPageDiv = styled.div`
+  width: 100vw;
+  height: 100vh;
+  ${flexBox('center', 'center')};
+`;
 
 const RegisterPage = () => {
-  return <div>register page</div>;
+  return (
+    <RegisterPageDiv>
+      <Register />
+    </RegisterPageDiv>
+  );
 };
 
 export default RegisterPage;


### PR DESCRIPTION
### 작업 내역
---
- [x] 회원가입 페이지
- [x] 라우팅 애니메이션
- [x] 회원가입 버튼과 연동

### 고민 및 해결
---

- 라우팅 애니메이션은 매력을 못 느끼겠어서 라이브러리로 구현 그마저 쉽지 않았다
- 아이디는 이메일 형식이어야할까?
- 멘토님 말씀 처럼 스타일드 컴포넌트는 export 문 밑으로 내리던가 분리하던가 하는게 좋을 것 같다
- useEffect 안의 함수를 추상화 시켜서 사용하라고 하셨는데 종속성 배열을 신경쓰면서 추상화하기가 쉽지 않다..
- 뒤로가기를 누르면 내가 보던 페이지가 그대로 존재하는 것이 UX측면에서 좋다고 생각
    - 현재 회원가입 페이지에서 뒤로가면 모달이 없어진다
    - 모달에도 라우팅이 달고싶다


### 데모 이미지
---

![ezgif-3-569cda916b0f](https://user-images.githubusercontent.com/45571631/142044805-ff87b3f7-92fa-47f0-b4cc-e7c0db0a68dc.gif)

