### PR TITLE
[잔업][뚱이] Swagger 적용 및 버그 수정

### DIFF
--- a/back/common/dto/file-upload.dto.ts
+++ b/back/common/dto/file-upload.dto.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class FileUploadDto {
   @ApiProperty({ type: 'string', format: 'binary' })
-  file?: any;
+  upload?: any;
 }

--- a/back/common/dto/files-upload.dto.ts
+++ b/back/common/dto/files-upload.dto.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class FilesUploadDto {
   @ApiProperty({ type: 'array', items: { type: 'string', format: 'binary' } })
-  files?: any[];
+  upload?: any[];
 }

--- a/back/config/database.config.ts
+++ b/back/config/database.config.ts
@@ -14,6 +14,7 @@ const databaseConfig: TypeOrmModuleOptions = {
   // autoLoadEntities: true,
   synchronize: false,
   logging: true,
+  timezone: 'KST',
 };
 
 export default databaseConfig;

--- a/back/src/auth/auth.service.ts
+++ b/back/src/auth/auth.service.ts
@@ -10,7 +10,7 @@ export class AuthService {
   async validateUser(beforeUsername: string, beforePassword: string) {
     const user = await this.userRepository.findOne({ username: beforeUsername });
 
-    if (!user || !compare(beforePassword, user.password)) return null;
+    if (!user || !(await compare(beforePassword, user.password))) return null;
 
     const result = {
       id: user.id,

--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -11,6 +11,7 @@ async function bootstrap() {
     .setDescription(`The PingPing's friends API description`)
     .setVersion('0.1.0')
     .addTag('pingpings')
+    .addBearerAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' })
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);

--- a/back/src/post/dto/create-post.dto.ts
+++ b/back/src/post/dto/create-post.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
+import { FilesUploadDto } from 'common/dto/files-upload.dto';
 
-export class CreatePostDto {
+export class CreatePostDto extends FilesUploadDto {
   @ApiProperty()
   @IsNumber()
   habitatId: number;

--- a/back/src/post/dto/patchPostRequestDto.ts
+++ b/back/src/post/dto/patchPostRequestDto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
+import { FilesUploadDto } from 'common/dto/files-upload.dto';
 
-export class PatchPostRequestDto {
+export class PatchPostRequestDto extends FilesUploadDto {
   @ApiProperty()
   @IsString()
   contentIds: string;

--- a/back/src/post/post.module.ts
+++ b/back/src/post/post.module.ts
@@ -2,10 +2,6 @@ import { Module } from '@nestjs/common';
 import { PostService } from './post.service';
 import { PostController } from './post.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Post } from './entities/post.entity';
-import { PostContent } from 'src/post-contents/entities/post-content.entity';
-import { Content } from 'src/contents/entities/content.entity';
-import { Heart } from 'src/hearts/entities/heart.entity';
 import { PostRepository } from './post.repository';
 
 @Module({

--- a/back/src/post/post.service.ts
+++ b/back/src/post/post.service.ts
@@ -78,14 +78,14 @@ export class PostService {
     return `
     select p.post_id, p.human_content, p.animal_content, p.created_at, u.user_id, u.username, u.nickname, c.url as user_image_url
     , group_concat(distinct pcc.url) as post_contents_urls, group_concat(distinct pcc.mime_type) as post_contents_types
-    , count(h.post_id) as numOfHearts
+    , (select count(*) from heart where post_id = p.post_id) as numOfHearts
+    , (select count(*) from comment where post_id = p.post_id) as numOfComments
     , if((select count(*) from heart where post_id = p.post_id and user_id = ?), true, false) as is_heart
     from post p
-    left join user u on u.user_id = p.user_id
-    left join contents c on c.contents_id = u.contents_id
-    left join post_contents pc on pc.post_id = p.post_id
-    left join contents pcc on pc.contents_id = pcc.contents_id
-    left join heart h on h.post_id = p.post_id
+    inner join user u on u.user_id = p.user_id
+    inner join contents c on c.contents_id = u.contents_id
+    inner join post_contents pc on pc.post_id = p.post_id
+    inner join contents pcc on pc.contents_id = pcc.contents_id
     `;
   }
 


### PR DESCRIPTION
### 작업 내역
---
- [x] User, Post API에 Swagger 적용
- [x] 타임존 알맞게 변경
- [x] 쿼리문 수정하여 connents url이 null인 컬럼 반환되지 않게 수정
- [x] 비밀번호 버그 해결

### 고민 및 해결
---
- timezone 수정
  - database의 timezone 수정
    <img width="338" alt="화면 캡처 2021-11-20 180441" src="https://user-images.githubusercontent.com/58130501/142728282-d7cae757-77ac-4711-b572-7b6a64bcfc80.png">

  - databaseConfig 수정
    - timezone: 'KST'

- Swagger
  - 컨트롤러나 라우터 해들러 메소드에 데코레이터가 늘어남에따라 어디까지가 메소드인지 헷갈리게 되고, 특정 데코레이터도 찾기 힘들다고 느껴짐.
  - 따라서 데코레이터 순서를 정했으면 좋겠음
  - 본인이 생각한 순서는 Method 데코레이터 - Api관련 데코레이터 - UseGuards - UseInterceptors -  usePipes 등등...

- 비밀번호 버그 해결
  - 조건문 안의 비교 메소드에서 promise 객체가 반환되어서 조건문의 결과가 true로 되어 인증이 통과하게 되는 거였음

### (필요시) 데모 이미지
---

TimeZone 이슈 해결 <s>화질구지 죄송</s>
<img width="1089" alt="화면 캡처 2021-11-20 175757" src="https://user-images.githubusercontent.com/58130501/142728705-b062ef6b-c539-44a2-90e9-f7f2548540f4.png">


#### swagger jwt 사용 방법
<a href="https://github.com/boostcampwm-2021/web20-SpongeBob/wiki/Swagger JWT 인증하여 테스트하기">Swagger에 JWT토큰 넣어서 test하는 방법</a>
