### PR TITLE
[W5][D1][뚱이] User, Post API 수정 및 추가

### DIFF
--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -72,6 +72,19 @@ export class PostController {
     return await this.postService.findAll(habitatId, lastPostId);
   }
 
+  @Get('users/:userId')
+  @ApiOperation({
+    summary: '유저 게시글 리스트 조회',
+    description: '특정 유저의 게시글 리스트를 조회하는 api입니다.',
+  })
+  @ApiQuery({ name: 'lastId', required: false })
+  async findAllByUserId(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Query('lastId', ParseOptionalIntPipe) lastId?: number
+  ) {
+    return await this.postService.findAllByUserId(userId, lastId);
+  }
+
   @Get(':id')
   @ApiOperation({
     summary: '특정 게시글 조회',

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -26,12 +26,14 @@ import {
   ApiCreatedResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import { GetPostResponseDto } from './dto/getPostResponse.dto';
 import { ParseOptionalIntPipe } from 'common/pipes/parse-optional-int.pipe';
 import { AuthGuard } from '@nestjs/passport';
 import FileDto from 'common/dto/transformFileDto';
+import { GetPostListResponseDto } from './dto/getPostListResponse.dto';
 
 @ApiTags('게시물 API')
 @Controller('posts')
@@ -62,6 +64,7 @@ export class PostController {
     summary: '게시글 리스트 조회',
     description: '페이지 별 게시글 리스트를 조회하는 api입니다.',
   })
+  @ApiQuery({ name: 'lastPostId', type: 'number', required: false })
   async findAll(
     @Param('habitatId', ParseIntPipe) habitatId: number,
     @Query('lastPostId', ParseOptionalIntPipe) lastPostId?: number

--- a/back/src/post/post.service.ts
+++ b/back/src/post/post.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Comment } from 'src/comments/entities/comment.entity';
 import { CreateContentDto } from 'src/contents/dto/create-content.dto';
 import { Content } from 'src/contents/entities/content.entity';
+import { Heart } from 'src/hearts/entities/heart.entity';
 import { PostContent } from 'src/post-contents/entities/post-content.entity';
 import { Connection } from 'typeorm';
 import { convertStringToNumber } from 'utils/value-converter.util';
@@ -40,6 +41,23 @@ export class PostService {
       );
       return result;
     }
+  }
+
+  async findAllByUserId(userId: number, lastId?: number) {
+    return await this.postRepository
+      .createQueryBuilder('post')
+      .select('post.id', 'postId')
+      .innerJoin('post.postContents', 'postContents')
+      .innerJoin('postContents.content', 'content')
+      .addSelect('min(content.url)', 'url')
+      .addSelect(
+        (qb) => qb.select('count(*)').from(Heart, 'heart').where('heart.postId = post.id'),
+        'numOfHearts'
+      )
+      .where('post.userId = :userId', { userId })
+      .groupBy('post.id')
+      .orderBy('post.id', 'DESC')
+      .getRawMany();
   }
 
   async getFirstPage(habitatId: number, userId: number) {

--- a/back/src/users/dto/create-user.dto.ts
+++ b/back/src/users/dto/create-user.dto.ts
@@ -3,5 +3,7 @@ export class CreateUserDto {
   password: string;
   nickname: string;
   habitatId: number;
-  speciesId: number;
+  speciesId?: number;
+  sound?: string;
+  name?: string;
 }

--- a/back/src/users/dto/register-user.dto.ts
+++ b/back/src/users/dto/register-user.dto.ts
@@ -1,7 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { FileUploadDto } from 'common/dto/file-upload.dto';
 
-export class RegisterUserDto extends FileUploadDto {
+export class RegisterUserDto {
+  @ApiProperty({ type: 'string', format: 'binary', required: false })
+  upload?: any;
+
   @ApiProperty()
   username: string;
 
@@ -14,6 +16,12 @@ export class RegisterUserDto extends FileUploadDto {
   @ApiProperty()
   habitatId: number;
 
-  @ApiProperty()
-  speciesId: number;
+  @ApiProperty({ required: false })
+  speciesId?: number;
+
+  @ApiProperty({ required: false })
+  sound: string;
+
+  @ApiProperty({ required: false })
+  name: string;
 }

--- a/back/src/users/entities/user.entity.ts
+++ b/back/src/users/entities/user.entity.ts
@@ -51,7 +51,7 @@ export class User {
   @JoinColumn({ name: 'contents_id', referencedColumnName: 'id' })
   content: Content;
 
-  @ManyToOne(() => Species, (species) => species.users)
+  @ManyToOne(() => Species, (species) => species.users, { cascade: ['insert'] })
   @JoinColumn({ name: 'species_id', referencedColumnName: 'id' })
   species: Species;
 
@@ -75,7 +75,6 @@ export class User {
   async hashPassword() {
     try {
       this.password = await bcrypt.hash(this.password, 10);
-      console.log(this.password);
     } catch (err) {
       throw new InternalServerErrorException();
     }

--- a/back/src/users/user.repository.ts
+++ b/back/src/users/user.repository.ts
@@ -1,6 +1,7 @@
 import FileDto from 'common/dto/transformFileDto';
 import { CreateContentDto } from 'src/contents/dto/create-content.dto';
 import { Content } from 'src/contents/entities/content.entity';
+import { Species } from 'src/species/entities/species.entity';
 import { EntityRepository, Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
@@ -10,11 +11,20 @@ export class UserRepository extends Repository<User> {
   async saveUser(createUserDto: CreateUserDto, contentInfo?: CreateContentDto) {
     const user = new User();
 
+    const { name, sound, speciesId } = createUserDto;
+
     user.username = createUserDto.username;
     user.nickname = createUserDto.nickname;
     user.password = createUserDto.password;
     user.habitatId = createUserDto.habitatId;
-    user.speciesId = createUserDto.speciesId;
+
+    if (speciesId) user.speciesId = speciesId;
+    else {
+      const species = new Species();
+      species.name = name;
+      species.sound = sound;
+      user.species = species;
+    }
 
     if (contentInfo) {
       const content = new Content();

--- a/back/src/users/users.controller.ts
+++ b/back/src/users/users.controller.ts
@@ -62,7 +62,7 @@ export class UsersController {
   @ApiConsumes('multipart/form-data')
   @ApiBody({ type: RegisterUserDto })
   @UseInterceptors(FileInterceptor('upload', multerUserOption))
-  register(@Body(ParseUsernamePipe) createUserDto: CreateUserDto, @UploadedFile() image: FileDto) {
+  register(@Body(ParseUsernamePipe) createUserDto: CreateUserDto, @UploadedFile() image?: FileDto) {
     return this.usersService.create(createUserDto, image);
   }
 

--- a/back/src/users/users.controller.ts
+++ b/back/src/users/users.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  Param,
+  ParseIntPipe,
   Patch,
   Post,
   Req,
@@ -43,7 +45,7 @@ export class UsersController {
 
   @Get()
   @ApiOperation({
-    summary: '유저 조회',
+    summary: '유저 리스트 조회',
     description: '모든 유저를 조회하는 api입니다.',
   })
   @ApiCreatedResponse({
@@ -52,6 +54,15 @@ export class UsersController {
   })
   findAll() {
     return this.usersService.findAll();
+  }
+
+  @Get(':userId')
+  @ApiOperation({
+    summary: '유저 정보 조회',
+    description: '유저의 정보를 조회하는 api입니다.',
+  })
+  async findOne(@Param('userId', ParseIntPipe) userId: number) {
+    return await this.usersService.findUser(userId);
   }
 
   @Post('register')
@@ -77,8 +88,7 @@ export class UsersController {
     type: User,
   })
   @UseGuards(AuthGuard('local'))
-  async login(@Request() req) {
-    console.log(req.user.id);
+  async login(@Request() req: any) {
     const { accessToken } = await this.authService.login(req.user);
     const user = await this.usersService.findUser(req.user.id);
 

--- a/back/src/users/users.service.ts
+++ b/back/src/users/users.service.ts
@@ -21,6 +21,11 @@ export class UsersService {
   }
 
   async create(createUserDto: CreateUserDto, image?: FileDto) {
+    const { name, sound, speciesId } = createUserDto;
+
+    if ((name || sound) && speciesId) return false;
+    if (!(name || sound) && !speciesId) return false;
+
     const foundUser = await this.userRepository.findOne({ username: createUserDto.username });
     if (foundUser) return false;
 

--- a/back/utils/value-converter.util.ts
+++ b/back/utils/value-converter.util.ts
@@ -1,0 +1,5 @@
+function convertStringToNumber<T>(entity: T, ...props: string[]): void {
+  props.forEach((prop: string) => (entity[prop] = +entity[prop]));
+}
+
+export { convertStringToNumber };


### PR DESCRIPTION
### 작업 내역
---
- [x] 게시물 리스트 조회 api의 lastPostId 리턴 수정
- [x] 회원가입 API 수정
- [x] 특정 유저 페이지 게시물 리스트 조회 API 구현

### 고민 및 해결
---
QueryBuilder로 삽질을 좀 했음.
[QueryBuilder](https://github.com/boostcampwm-2021/web20-PingPingsFriends/wiki/QueryBuilder-%EC%98%A4%EB%A5%98)

유저 페이지의 게시물 리스트 조회에서 
페이지 네이션을 커서 페이지네이션으로 할 건지? 
페이지 단위로 끊을건지? 
역시나 고민됨. 우선 모두 가져오는 것을 해놓고 상의 후 바로 구현할 예정

우리가 겪었던 고민 또는 이슈와 해결 과정을 정리해서 위키에 기록하면 좋을 것 같음.

### (필요시) 데모 이미지
---
