### PR TITLE
[W5][D1][스폰지밥] 로깅 구현 , 이미지 리사이징 수정

### DIFF
--- a/back/config/database.config.ts
+++ b/back/config/database.config.ts
@@ -13,7 +13,7 @@ const databaseConfig: TypeOrmModuleOptions = {
   entities: [__dirname + '/../**/*.entity{.ts,.js}'],
   // autoLoadEntities: true,
   synchronize: false,
-  logging: true,
+  logging: false,
 };
 
 export default databaseConfig;

--- a/back/config/logger.config.ts
+++ b/back/config/logger.config.ts
@@ -1,0 +1,4 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+export const loggerEnv = process.env.NODE_ENV === 'dev' ? 'dev' : 'combined';

--- a/back/config/s3.config.ts
+++ b/back/config/s3.config.ts
@@ -20,9 +20,9 @@ export const multerUserOption = {
     shouldTransform: true,
     transforms: [
       {
-        id: 'resized',
+        id: 'profile',
         key: function (request, file, cb) {
-          cb(null, `${uuidv1().toString()}.webp`);
+          cb(null, `${uuidv1().toString()}-profile.webp`);
         },
         transform: function (req, file, cb) {
           cb(null, sharp().resize({ width: 100, height: 100 }).webp({ quality: 80 }));
@@ -31,6 +31,9 @@ export const multerUserOption = {
     ],
     bucket: 'spongebob-bucket',
     acl: 'public-read',
+    contentType: function (req, file, cb) {
+      cb(null, 'image/webp');
+    },
   }),
 };
 
@@ -42,12 +45,15 @@ export const multerTransFormOption = () => {
       shouldTransform: true,
       transforms: [
         {
-          id: 'resized',
+          id: 'feed',
           key: function (request, file, cb) {
-            cb(null, `${uuidKey}-resized.webp`);
+            cb(null, `${uuidKey}-feed.webp`);
           },
           transform: function (req, file, cb) {
-            cb(null, sharp().webp({ quality: 80 }));
+            cb(
+              null,
+              sharp({ animated: true }).resize({ width: 470, height: 500 }).webp({ quality: 80 })
+            );
           },
         },
         {
@@ -56,12 +62,15 @@ export const multerTransFormOption = () => {
             cb(null, `${uuidKey}.webp`);
           },
           transform: function (req, file, cb) {
-            cb(null, sharp().webp({ quality: 90 }));
+            cb(null, sharp({ animated: true }).webp({ quality: 90 }));
           },
         },
       ],
       bucket: 'spongebob-bucket',
       acl: 'public-read',
+      contentType: function (req, file, cb) {
+        cb(null, 'image/webp');
+      },
     }),
   };
 };

--- a/back/config/s3.config.ts
+++ b/back/config/s3.config.ts
@@ -2,7 +2,7 @@ import * as AWS from 'aws-sdk';
 import * as multerS3 from 'multer-s3-transform';
 import * as dotenv from 'dotenv';
 import * as sharp from 'sharp';
-
+import { v1 as uuidv1 } from 'uuid';
 dotenv.config();
 
 const s3 = new AWS.S3({
@@ -22,7 +22,7 @@ export const multerUserOption = {
       {
         id: 'resized',
         key: function (request, file, cb) {
-          cb(null, `${Date.now().toString()}.webp`);
+          cb(null, `${uuidv1().toString()}.webp`);
         },
         transform: function (req, file, cb) {
           cb(null, sharp().resize({ width: 100, height: 100 }).webp({ quality: 80 }));
@@ -34,22 +34,34 @@ export const multerUserOption = {
   }),
 };
 
-export const multerTransFormOption = {
-  storage: multerS3({
-    s3,
-    shouldTransform: true,
-    transforms: [
-      {
-        id: 'transform',
-        key: function (request, file, cb) {
-          cb(null, `${Date.now().toString()}.webp`);
+export const multerTransFormOption = () => {
+  const uuidKey = uuidv1().toString();
+  return {
+    storage: multerS3({
+      s3,
+      shouldTransform: true,
+      transforms: [
+        {
+          id: 'resized',
+          key: function (request, file, cb) {
+            cb(null, `${uuidKey}-resized.webp`);
+          },
+          transform: function (req, file, cb) {
+            cb(null, sharp().webp({ quality: 80 }));
+          },
         },
-        transform: function (req, file, cb) {
-          cb(null, sharp().webp({ quality: 80 }));
+        {
+          id: 'origin',
+          key: function (request, file, cb) {
+            cb(null, `${uuidKey}.webp`);
+          },
+          transform: function (req, file, cb) {
+            cb(null, sharp().webp({ quality: 90 }));
+          },
         },
-      },
-    ],
-    bucket: 'spongebob-bucket',
-    acl: 'public-read',
-  }),
+      ],
+      bucket: 'spongebob-bucket',
+      acl: 'public-read',
+    }),
+  };
 };

--- a/back/logger/logger.controller.ts
+++ b/back/logger/logger.controller.ts
@@ -1,0 +1,21 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+
+import { Request, Response } from 'express';
+import { AppLoggingService } from './logger.service';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  constructor() {}
+
+  use(req: Request, res: Response, next: Function) {
+    const loggerService = new AppLoggingService(req.url.slice(1).split('/')[0]);
+    const tempUrl = req.method + ' ' + req.url.split('?')[0];
+    const _headers = JSON.stringify(req.headers ? req.headers : {});
+    const _query = JSON.stringify(req.query ? req.query : {});
+    const _body = JSON.stringify(req.body ? req.body : {});
+    const _url = JSON.stringify(tempUrl ? tempUrl : {});
+
+    loggerService.log(`${_url} ${_headers} ${_query} ${_body}`.replace(/\\/, ''));
+    next();
+  }
+}

--- a/back/logger/logger.service.ts
+++ b/back/logger/logger.service.ts
@@ -1,0 +1,56 @@
+import { LoggerService } from '@nestjs/common';
+import 'winston-daily-rotate-file';
+import * as winston from 'winston';
+import { Logger, format } from 'winston';
+import { loggerEnv } from 'config/logger.config';
+
+const { combine, timestamp, prettyPrint, colorize, errors, json, ms, simple } = format;
+const logDir = 'logs';
+export class AppLoggingService implements LoggerService {
+  private logger: Logger;
+
+  constructor(service) {
+    this.logger = winston.createLogger({
+      level: 'info',
+      format: combine(
+        errors({ stack: true }), // <-- use errors format
+        timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+        json(),
+        ms(),
+        colorize({ all: true }),
+        prettyPrint()
+      ),
+      defaultMeta: { service },
+      transports: [],
+    });
+
+    if (loggerEnv !== 'dev') {
+      this.logger.add(
+        new winston.transports.DailyRotateFile({
+          level: 'http',
+          datePattern: 'YYYY-MM-DD',
+          dirname: logDir,
+          filename: `%DATE%.log`,
+          maxFiles: 14, // 14일치 로그 파일 저장
+          zippedArchive: true,
+        })
+      );
+    }
+  }
+
+  log(message: string) {
+    this.logger.info(message);
+  }
+  error(message: string, trace: string) {
+    this.logger.error(message, trace);
+  }
+  warn(message: string) {
+    this.logger.warning(message);
+  }
+  debug(message: string) {
+    this.logger.debug(message);
+  }
+  verbose(message: string) {
+    this.logger.verbose(message);
+  }
+}

--- a/back/package.json
+++ b/back/package.json
@@ -50,6 +50,7 @@
     "sharp": "^0.29.3",
     "swagger-ui-express": "^4.1.6",
     "typeorm": "^0.2.38",
+    "uuid": "^8.3.2",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.5"
   },

--- a/back/package.json
+++ b/back/package.json
@@ -29,12 +29,14 @@
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/swagger": "^5.1.4",
     "@nestjs/typeorm": "^8.0.2",
+    "@types/morgan": "^1.9.3",
     "@types/sharp": "^0.29.4",
     "aws-sdk": "^2.1020.0",
     "bcrypt": "^5.0.1",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "dotenv": "^10.0.0",
+    "morgan": "^1.10.0",
     "multer": "^1.4.3",
     "multer-s3": "^2.10.0",
     "multer-s3-transform": "^2.10.3",
@@ -47,7 +49,9 @@
     "rxjs": "^7.2.0",
     "sharp": "^0.29.3",
     "swagger-ui-express": "^4.1.6",
-    "typeorm": "^0.2.38"
+    "typeorm": "^0.2.38",
+    "winston": "^3.3.3",
+    "winston-daily-rotate-file": "^4.5.5"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.0.0",

--- a/back/src/app.module.ts
+++ b/back/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { UsersModule } from './users/users.module';
 import { PostModule } from './post/post.module';
 import { HabitatModule } from './habitat/habitat.module';
@@ -9,6 +9,7 @@ import { CommentsModule } from './comments/comments.module';
 import { HeartsModule } from './hearts/hearts.module';
 import { AuthModule } from './auth/auth.module';
 import databaseConfig from '../config/database.config';
+import { LoggerMiddleware } from 'logger/logger.controller';
 
 @Module({
   imports: [
@@ -23,4 +24,8 @@ import databaseConfig from '../config/database.config';
     AuthModule,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    //consumer.apply(LoggerMiddleware).forRoutes('*');
+  }
+}

--- a/back/src/app.module.ts
+++ b/back/src/app.module.ts
@@ -26,6 +26,6 @@ import { LoggerMiddleware } from 'logger/logger.controller';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    //consumer.apply(LoggerMiddleware).forRoutes('*');
+    // consumer.apply(LoggerMiddleware).forRoutes('*');
   }
 }

--- a/back/src/habitat/habitat.controller.ts
+++ b/back/src/habitat/habitat.controller.ts
@@ -1,20 +1,8 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-  Query,
-  ParseIntPipe,
-} from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, ParseIntPipe } from '@nestjs/common';
 import { HabitatService } from './habitat.service';
 import { CreateHabitatDto } from './dto/create-habitat.dto';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PaginationQueryDto } from 'common/dto/pagination-query.dto';
-import { query } from 'winston';
-import { IsDuplicatedDto } from './dto/is-duplicated.dto';
 
 @Controller('habitat')
 @ApiTags('서식지 API')
@@ -46,7 +34,7 @@ export class HabitatController {
     description: '유저가 서식지를 추가한다.',
   })
   createHabitat(@Body() createHabitatDto: CreateHabitatDto) {
-    return this.habitatService.createHabitat(createHabitatDto, 1);
+    return this.habitatService.createHabitat(createHabitatDto, 3);
   }
 
   @Get()

--- a/back/src/habitat/habitat.controller.ts
+++ b/back/src/habitat/habitat.controller.ts
@@ -13,6 +13,8 @@ import { HabitatService } from './habitat.service';
 import { CreateHabitatDto } from './dto/create-habitat.dto';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PaginationQueryDto } from 'common/dto/pagination-query.dto';
+import { query } from 'winston';
+import { IsDuplicatedDto } from './dto/is-duplicated.dto';
 
 @Controller('habitat')
 @ApiTags('서식지 API')
@@ -27,6 +29,15 @@ export class HabitatController {
   @ApiCreatedResponse({ description: '랜덤서식지10개 배열반환.' })
   getRandomHabitat(@Query('currentId', ParseIntPipe) currentId: number) {
     return this.habitatService.getRandomHabitat(currentId);
+  }
+
+  @Get('isDuplicated')
+  @ApiOperation({
+    summary: '서식지 이름 중복 체크 API',
+    description: '서식지 이름 중복 여부 반환',
+  })
+  isDuplicate(@Query('name') name: string) {
+    return this.habitatService.isDuplicate(name);
   }
 
   @Post()

--- a/back/src/habitat/habitat.service.ts
+++ b/back/src/habitat/habitat.service.ts
@@ -1,9 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PaginationQueryDto } from 'common/dto/pagination-query.dto';
 import { PostRepository } from 'src/post/post.repository';
 import { UserRepository } from 'src/users/user.repository';
 import { CreateHabitatDto } from './dto/create-habitat.dto';
-import { IsDuplicatedDto } from './dto/is-duplicated.dto';
 import { HabitatRepository } from './habitat.repository';
 
 @Injectable()
@@ -14,7 +13,9 @@ export class HabitatService {
     private readonly userRepository: UserRepository
   ) {}
 
-  createHabitat(createHabitatDto: CreateHabitatDto, leaderId: number) {
+  async createHabitat(createHabitatDto: CreateHabitatDto, leaderId: number) {
+    if (await this.isDuplicate(createHabitatDto.name))
+      throw new HttpException('Error: 중복된 서식지 이름입니다.', HttpStatus.BAD_REQUEST);
     return this.habitatRepository.createHabitat(createHabitatDto, leaderId);
   }
 

--- a/back/src/habitat/habitat.service.ts
+++ b/back/src/habitat/habitat.service.ts
@@ -3,6 +3,7 @@ import { PaginationQueryDto } from 'common/dto/pagination-query.dto';
 import { PostRepository } from 'src/post/post.repository';
 import { UserRepository } from 'src/users/user.repository';
 import { CreateHabitatDto } from './dto/create-habitat.dto';
+import { IsDuplicatedDto } from './dto/is-duplicated.dto';
 import { HabitatRepository } from './habitat.repository';
 
 @Injectable()
@@ -42,5 +43,10 @@ export class HabitatService {
   async getRandomHabitat(currentId: number) {
     const result = await this.habitatRepository.selectRandomHabitat(currentId);
     return result.map(({ id }) => id);
+  }
+
+  async isDuplicate(name: string) {
+    const result = await this.habitatRepository.findOne({ name });
+    return result ? true : false;
   }
 }

--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -1,9 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import * as morgan from 'morgan';
+import { loggerEnv } from 'config/logger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.use(morgan(loggerEnv));
   app.enableCors();
   app.setGlobalPrefix('api', { exclude: ['docs'] });
   const config = new DocumentBuilder()

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -47,7 +47,7 @@ export class PostController {
   @ApiConsumes('multipart/form-data')
   @ApiBody({ type: CreatePostDto })
   @UseGuards(AuthGuard('jwt'))
-  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption))
+  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption()))
   async uploadFile(
     @Body() createPostDto: CreatePostDto,
     @UploadedFiles() files: FileDto[],
@@ -89,7 +89,7 @@ export class PostController {
   @ApiBody({ type: PatchPostRequestDto })
   @ApiCreatedResponse({ type: Boolean })
   @UseGuards(AuthGuard('jwt'))
-  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption))
+  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption()))
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() patchPostRequestDto: PatchPostRequestDto,

--- a/back/src/species/dto/create-species.dto.ts
+++ b/back/src/species/dto/create-species.dto.ts
@@ -4,9 +4,9 @@ import { IsNotEmpty } from 'class-validator';
 export class CreateSpeciesDto {
   @ApiProperty()
   @IsNotEmpty()
-  sound: string;
+  name: string;
 
   @ApiProperty()
   @IsNotEmpty()
-  name: string;
+  sound: string;
 }

--- a/back/src/species/species.controller.ts
+++ b/back/src/species/species.controller.ts
@@ -17,7 +17,14 @@ export class SpeciesController {
   create(@Body() createSpeciesDto: CreateSpeciesDto) {
     return this.speciesService.create(createSpeciesDto);
   }
-
+  @Get('isDuplicated')
+  @ApiOperation({
+    summary: '동물 카테고리 이름 중복 체크 API',
+    description: '동물 카테고리 이름 중복 여부 반환',
+  })
+  isDuplicate(@Query('name') name: string) {
+    return this.speciesService.isDuplicate(name);
+  }
   // @Get()
   // @ApiOperation({
   //   summary: '동물 카테고리 조회 API',

--- a/back/src/species/species.service.ts
+++ b/back/src/species/species.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CursorPaginationDto } from 'common/dto/cursor-pagination.dto';
 import { CreateSpeciesDto } from './dto/create-species.dto';
@@ -12,7 +12,9 @@ export class SpeciesService {
     private speciesRepository: SpeciesRepository
   ) {}
 
-  create({ name, sound }: CreateSpeciesDto) {
+  async create({ name, sound }: CreateSpeciesDto) {
+    if (await this.isDuplicate(name))
+      throw new HttpException('Error: 중복된 동물 카테고리 이름입니다.', HttpStatus.BAD_REQUEST);
     const species = new Species();
     species.name = name;
     species.sound = sound;
@@ -24,5 +26,10 @@ export class SpeciesService {
     return cursorPaginationDto.lastId === undefined
       ? this.speciesRepository.selectSpeciesListFirst(limit)
       : this.speciesRepository.selectSpeciesListByCursor(cursorPaginationDto.lastId, limit);
+  }
+
+  async isDuplicate(name: string) {
+    const result = await this.speciesRepository.findOne({ name });
+    return result ? true : false;
   }
 }

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -5886,7 +5886,7 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@8.3.2:
+uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -370,6 +370,15 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@eslint/eslintrc@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.4.tgz#dfe0ff7ba270848d10c5add0715e04964c034b31"
@@ -951,6 +960,13 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
+"@types/morgan@^1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@types/morgan/-/morgan-1.9.3.tgz#ae04180dff02c437312bc0cfb1e2960086b2f540"
+  integrity sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/multer-s3@^2.7.10":
   version "2.7.11"
   resolved "https://registry.yarnpkg.com/@types/multer-s3/-/multer-s3-2.7.11.tgz#584301fe4965520078c1bebe3ddf72ab32ada414"
@@ -1521,6 +1537,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+async@^3.1.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
+  integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1623,6 +1644,13 @@ base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 bcrypt@^5.0.1:
   version "5.0.1"
@@ -1940,7 +1968,7 @@ collect-v8-coverage@^1.0.0:
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
   integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1977,6 +2005,14 @@ color-support@^1.1.2:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
+
 color@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/color/-/color-4.0.1.tgz#21df44cd10245a91b1ccf5ba031609b0e10e7d67"
@@ -1985,10 +2021,18 @@ color@^4.0.1:
     color-convert "^2.0.1"
     color-string "^1.6.0"
 
-colors@^1.1.2:
+colors@^1.1.2, colors@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -2208,6 +2252,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -2298,6 +2347,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2669,6 +2723,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fecha@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
+  integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
+
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -2682,6 +2741,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-stream-rotator@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.5.7.tgz#868a2e5966f7640a17dd86eda0e4467c089f6286"
+  integrity sha512-VYb3HZ/GiAGUCrfeakO8Mp54YGswNUHvL7P09WQcXAJNSj3iQ5QraYSp3cIn1MUyw6uzfgN/EFOarCNa4JvUHQ==
+  dependencies:
+    moment "^2.11.2"
 
 file-type@^3.3.0:
   version "3.9.0"
@@ -2728,6 +2794,11 @@ flatted@^3.1.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@^1.14.4:
   version "1.14.5"
@@ -3926,6 +3997,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -4026,6 +4102,17 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+logform@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.3.0.tgz#a3997a05985de2ebd325ae0d166dffc9c6fe6b57"
+  integrity sha512-graeoWUH2knKbGthMtuG1EfaSPMZFZBIrhuJHhkS5ZseFBrc7DupCzihOQAzsK/qIKPQaPJ/lFQFctILUY5ARQ==
+  dependencies:
+    colors "^1.2.1"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^1.1.0"
+    triple-beam "^1.3.0"
 
 long@^4.0.0:
   version "4.0.0"
@@ -4193,6 +4280,22 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moment@^2.11.2:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
 
 ms@2.0.0:
   version "2.0.0"
@@ -4401,7 +4504,7 @@ object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-hash@2.2.0:
+object-hash@2.2.0, object-hash@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
@@ -4418,12 +4521,24 @@ on-finished@^2.3.0, on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
@@ -4818,7 +4933,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.6, readable-stream@^2.2.2:
+readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -4959,6 +5074,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-stable-stringify@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz#c8a220ab525cd94e60ebf47ddc404d610dc5d84a"
+  integrity sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -5193,6 +5313,11 @@ sqlstring@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.2.tgz#cdae7169389a1375b18e885f2e60b3e460809514"
   integrity sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^2.0.3:
   version "2.0.5"
@@ -5451,6 +5576,11 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -5534,6 +5664,11 @@ tree-kill@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 ts-jest@^27.0.3:
   version "27.0.7"
@@ -5920,6 +6055,39 @@ windows-release@^4.0.0:
   integrity sha512-OxmV4wzDKB1x7AZaZgXMVsdJ1qER1ed83ZrTYd5Bwq2HfJVg3DJS8nqlAG4sMoJ7mu8cuRmLEYyU13BKwctRAg==
   dependencies:
     execa "^4.0.2"
+
+winston-daily-rotate-file@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.5.5.tgz#cfa3a89f4eb0e4126917592b375759b772bcd972"
+  integrity sha512-ds0WahIjiDhKCiMXmY799pDBW+58ByqIBtUcsqr4oDoXrAI3Zn+hbgFdUxzMfqA93OG0mPLYVMiotqTgE/WeWQ==
+  dependencies:
+    file-stream-rotator "^0.5.7"
+    object-hash "^2.0.1"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
+
+winston-transport@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
+  dependencies:
+    readable-stream "^2.3.7"
+    triple-beam "^1.2.0"
+
+winston@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
+  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.1.0"
+    is-stream "^2.0.0"
+    logform "^2.2.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### 작업 내역
---
- [x] 이미지 리사이징 로직 수정
- [x] NestJS Logger 구현
- [x] 서식지, 동물 카테고리 API 생성시 중복체크 애러 핸들링 
- [x] 서식지, 동물 카테고리 중복체크 API 추가 [name=이신필]

## 고민 및 해결
---
### 로깅 삽질

- Express에서 깔끔한 콘솔로그를 보여줬던 `morgan`을 dev환경에서 사용하기 위해 적용함
   -> express generator만 써서 express 자체적으로 구성된 로깅인줄 알았는데 그게아니고 express-morgan이 적용되어야
        http 요청에 대한 로깅을 할 수 있음 (혹은 직접구현)
- production 환경에서 로그를 파일로 저장할 수 있는 `winston` 라이브러리를 적용 -> 적용 취소
  -> 처음에는 위에서 언급했던 morgan툴을 쓰지않고 nestJS 자체 로깅 시스템에 winston을 덮어 씌워서 만드려고 했다.

  -> 참고 예제 코드를 토대로 `미들웨어`로 구현해서 적용해 보았다. 로그 포맷도 직접 지정해야해서 이쁘지 않았고, 가장 중요한 
       http response부분을 로그에 담으려면 `핸들러` 뒤에 올 수 있는 `인터셉터`로 구현해야 할 것 같다고 생각했다.

  -> 이미 구현에 삽질을 많이 해서 시간이 부족했던 차라 dev환경에서는 `morgan`라이브러리에 맡기거나, `morgan`과 `winston`  
       을 연동하면 좋을 것으로 생각했지만 시간 부족으로 따로 사용하기로 했다.

  -> dotenv파일로 dev환경과 production환경을 변수로 구분하여 사용했다. 추후 dotenv 공유 예정

  -> `로깅 래밸` 이라고 공식적으로 정해진 로그의 레벨이 있다. 아래와 비슷한 형식인데 이 레벨별로 저장할 로그를 구분할 수 
       있다. info level과 error level을 각각 분리해서 저장하려했지만...info는 성공, error는 실패했다. 서버에서 나는 error가 인식이 
       되지않는지 error level로 인식하지 못했다. info level 로그만 저장하고 넘어갔다.

![image](https://user-images.githubusercontent.com/42242359/142955399-f7627ef9-9970-46ed-bcc7-3460c0b3f37b.png)

  -> 따로 구현을 했더니 dev환경에서는 아래 처럼 로그가 두개로나온다...더러운 `winston`을 콘솔로그만 지워주려했지만 실패
![image](https://user-images.githubusercontent.com/42242359/142954974-4afe8b5d-b2d0-4d47-bc5a-4c288c584ab9.png)

  -> `winston`적용을 미뤄야한다고 판단하고 주석처리해서 적용을 취소하였다...나중에 시간나면 다시 해보면 좋을듯 합니다...
(node 개발은 로깅처리가 영 좋은 라이브러리가 없는 것 같다... 멘토님이 언급하신 것 처럼 직접 구현하던지 다른 서비스를 사용하는게 좋은 것 같다...)

### 이미지 리사이징
- 현재 파일명 매기는 방식이 중복이 되거나, xss공격등으로 악용될 수 있다고 생각해서 `uuid`를 사용해서 바꿔주었다.
- origin 과 resized로 두 가지가 저장됨 스펙은 다음과같다.
```
orgin: webp , 90프로 품질 압축, 리사이징 안함
resized: origin과 동일, 크기만 추가로변경 ->>>> 깜빡하고 리사이징을 안했다. 코드리뷰때 사이즈 몇으로할지 얘기나눠봅시다
```
- 아래처럼 뒤에 주소만 조금 바꾸면 접근가능하다. db에는 resized로 저장이 되니 사용시 주의바람
![image](https://user-images.githubusercontent.com/42242359/142955885-5b633daa-49c9-4380-ad58-c1235f60712b.png)

### 중복 체크 api
- 무난하게 구현함, 중복 체크해주는 api를 서식지, 동물카테고리 각각 추가함
- 기존의 서식지,동물카테고리 생성 api에 중복체크 애러를 추가했다.

### 발견한 오류들
- database.config.ts에 한국 시간대설정이 추가되고나서 해당 오류가발생하는 것 같음 
![image](https://user-images.githubusercontent.com/42242359/142956155-5d000cb3-4975-4155-94a0-063b065b3f54.png)
- post delete api에서 오류가 발생하는데 확인 바람!

### (필요시) 데모 이미지
---
