### PR TITLE
[W5][D2][다람이] 유저 페이지 구현, 글삭제, 글수정 모달 api 연결

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -19,14 +19,16 @@ function App() {
         <Route path="/explore">
           <ExplorePage />
         </Route>
-        <UserProvider>
-          <Route path="/user">
+        <Route path="/user/:id">
+          <UserProvider>
             <UserPage />
-          </Route>
-          <Route path="/">
+          </UserProvider>
+        </Route>
+        <Route path="/">
+          <UserProvider>
             <MainPage />
-          </Route>
-        </UserProvider>
+          </UserProvider>
+        </Route>
       </Switch>
     </>
   );

--- a/front/src/components/DeleteModal/DeleteModal.tsx
+++ b/front/src/components/DeleteModal/DeleteModal.tsx
@@ -1,8 +1,58 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Palette } from '@lib/styles/Palette';
 import { flexBox } from '@lib/styles/mixin';
 import { ToggleHandler } from '@common/Modal/useModal';
+import { useUserState } from '@src/contexts/UserContext';
+import { useHistory } from 'react-router';
+
+interface DeleteModalProps {
+  hide: ToggleHandler;
+  feedId: number;
+}
+
+const DeleteModal = ({ hide, feedId }: DeleteModalProps) => {
+  const userState = useUserState();
+  const [onDelete, setDelete] = useState(false);
+  const history = useHistory();
+
+  const handleDelete = async () => {
+    if (!userState.data) {
+      hide('off');
+      return;
+    }
+    setDelete(true);
+    const res: Response = await fetch(`/api/posts/${feedId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${userState.data.accessToken}` } });
+    console.log(res);
+    if (res.ok) {
+      history.go(0);
+    } else {
+      setDelete(false);
+    }
+  };
+
+  return (
+    <DeleteModalDiv>
+      {onDelete ? (
+        '삭제중입니다...'
+      ) : (
+        <>
+          <span>삭제하시겠습니까?</span>
+          <ButtonContainerDiv>
+            <button className={'cancel modal-close-button'} onClick={hide}>
+              취소
+            </button>
+            <button className={'confirm'} onClick={handleDelete}>
+              확인
+            </button>
+          </ButtonContainerDiv>
+        </>
+      )}
+    </DeleteModalDiv>
+  );
+};
+
+export default DeleteModal;
 
 const DeleteModalDiv = styled.div`
   ${flexBox('center', 'center', 'column')};
@@ -30,23 +80,3 @@ const ButtonContainerDiv = styled.div`
     }
   }
 `;
-
-interface DeleteModalProps {
-  hide: ToggleHandler;
-}
-
-const DeleteModal = ({ hide }: DeleteModalProps) => {
-  return (
-    <DeleteModalDiv>
-      <span>삭제하시겠습니까?</span>
-      <ButtonContainerDiv>
-        <button className={'cancel modal-close-button'} onClick={hide}>
-          취소
-        </button>
-        <button className={'confirm modal-close-button'}>확인</button>
-      </ButtonContainerDiv>
-    </DeleteModalDiv>
-  );
-};
-
-export default DeleteModal;

--- a/front/src/components/DetailModal/DetailContainer.tsx
+++ b/front/src/components/DetailModal/DetailContainer.tsx
@@ -31,6 +31,8 @@ const DetailContainer = ({ detailFeed, toggle }: DetailContainerProps) => {
       <div className={'contents'}>
         <DetailModal
           feedId={detailFeed.post_id}
+          userId={detailFeed.user_id}
+          userImgURL={detailFeed.user_image_url}
           imageURLs={detailFeed.contents_url_array}
           text={detailFeed.human_content}
           nickname={detailFeed.nickname}

--- a/front/src/components/DetailModal/DetailModal.tsx
+++ b/front/src/components/DetailModal/DetailModal.tsx
@@ -17,11 +17,13 @@ interface DetailModalProps extends LikeProps {
   nickname: string;
   text: string;
   feedId: number;
+  userId: number;
   ago: string;
   numOfHearts: string;
+  userImgURL: string | null;
 }
 
-const DetailModal = ({ feedId, imageURLs, nickname, text, ago, like, toggleLike, numOfHearts }: DetailModalProps) => {
+const DetailModal = ({ feedId, userId, userImgURL, imageURLs, nickname, text, ago, like, toggleLike, numOfHearts }: DetailModalProps) => {
   const [editMode, setEditMode] = useState(false);
   const [inputText, setInputText] = useState('');
   const toggleEditMode = (text: string) => {
@@ -45,7 +47,7 @@ const DetailModal = ({ feedId, imageURLs, nickname, text, ago, like, toggleLike,
       <CommunicateDiv>
         <FeedInfoDiv>
           <FeedAuthorDiv>
-            <Avatar size={'35px'} />
+            <Avatar size={'35px'} userId={userId} imgSrc={userImgURL ?? undefined} />
             <span className={'nickname'}>{nickname}</span>
             <span className={'time'}>{ago} 전</span>
           </FeedAuthorDiv>

--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -14,6 +14,7 @@ import DeleteModal from '@components/DeleteModal/DeleteModal';
 import DetailModal from '@components/DetailModal/DetailModal';
 import useModal from '@common/Modal/useModal';
 import { formatDate } from '@lib/utils/time';
+import { useUserState } from '@src/contexts/UserContext';
 
 export interface FeedProps {
   feedId: number;
@@ -34,15 +35,18 @@ const Feed = ({ feedId, userId, nickname, imageURLs, text, lazy, createdTime, nu
   const ago = formatDate(createdTime);
   const items = makeDropBoxMenu([{ text: '글 수정' }, { text: '글 삭제', handler: toggleDeleteModal }]);
   const { toggle, routePath } = useModal(`detail/${feedId}`);
+  const userState = useUserState();
 
   return (
     <FeedContainerDiv>
       <FeedHeaderDiv>
         <Avatar size={'30px'} imgSrc={avatarImage} userId={userId} />
         <span>{nickname}</span>
-        <DropBox start="right" offset={10} top={55} width={150} items={items}>
-          <VertBtnSvg className="vert_btn button" />
-        </DropBox>
+        {userState.data?.userId === userId && (
+          <DropBox start="right" offset={10} top={55} width={150} items={items}>
+            <VertBtnSvg className="vert_btn button" />
+          </DropBox>
+        )}
       </FeedHeaderDiv>
       <FeedContents>
         <Carousel imageURLs={imageURLs} lazy={lazy} />

--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -12,6 +12,7 @@ import { makeDropBoxMenu } from '@common/DropBox/makeDropBoxMenu';
 import Modal from '@common/Modal/Modal';
 import DeleteModal from '@components/DeleteModal/DeleteModal';
 import DetailModal from '@components/DetailModal/DetailModal';
+import WriteModal from '@components/Write/WriteModal';
 import useModal from '@common/Modal/useModal';
 import { formatDate } from '@lib/utils/time';
 import { useUserState } from '@src/contexts/UserContext';
@@ -31,9 +32,13 @@ export interface FeedProps {
 
 const Feed = ({ feedId, userId, nickname, imageURLs, text, lazy, createdTime, numOfHearts, is_heart, avatarImage }: FeedProps) => {
   const { isShowing: isDeleteShowing, toggle: toggleDeleteModal } = useModal();
+  const { isShowing: isEditShowing, toggle: toggleEditModal } = useModal();
   const [like, toggleLike] = useLike(is_heart, feedId);
   const ago = formatDate(createdTime);
-  const items = makeDropBoxMenu([{ text: '글 수정' }, { text: '글 삭제', handler: toggleDeleteModal }]);
+  const items = makeDropBoxMenu([
+    { text: '글 수정', handler: toggleEditModal },
+    { text: '글 삭제', handler: toggleDeleteModal },
+  ]);
   const { toggle, routePath } = useModal(`detail/${feedId}`);
   const userState = useUserState();
 
@@ -59,7 +64,10 @@ const Feed = ({ feedId, userId, nickname, imageURLs, text, lazy, createdTime, nu
       </FeedInfoDiv>
       <FeedTextDiv>{text}</FeedTextDiv>
       <Modal isShowing={isDeleteShowing} hide={toggleDeleteModal}>
-        <DeleteModal hide={toggleDeleteModal} />
+        <DeleteModal hide={toggleDeleteModal} feedId={feedId} />
+      </Modal>
+      <Modal isShowing={isEditShowing} hide={toggleEditModal}>
+        <WriteModal hide={toggleEditModal} initState={{ contents: imageURLs, feedId: feedId, text: text }} />
       </Modal>
       <Modal hide={toggle} routePath={routePath}>
         <DetailModal

--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -28,7 +28,7 @@ export interface FeedProps {
   lazy?: (node: HTMLDivElement) => void;
 }
 
-const Feed = ({ feedId, nickname, imageURLs, text, lazy, createdTime, numOfHearts, is_heart, avatarImage }: FeedProps) => {
+const Feed = ({ feedId, userId, nickname, imageURLs, text, lazy, createdTime, numOfHearts, is_heart, avatarImage }: FeedProps) => {
   const { isShowing: isDeleteShowing, toggle: toggleDeleteModal } = useModal();
   const [like, toggleLike] = useLike(is_heart, feedId);
   const ago = formatDate(createdTime);
@@ -38,7 +38,7 @@ const Feed = ({ feedId, nickname, imageURLs, text, lazy, createdTime, numOfHeart
   return (
     <FeedContainerDiv>
       <FeedHeaderDiv>
-        <Avatar size={'30px'} imgSrc={avatarImage} />
+        <Avatar size={'30px'} imgSrc={avatarImage} userId={userId} />
         <span>{nickname}</span>
         <DropBox start="right" offset={10} top={55} width={150} items={items}>
           <VertBtnSvg className="vert_btn button" />
@@ -58,7 +58,19 @@ const Feed = ({ feedId, nickname, imageURLs, text, lazy, createdTime, numOfHeart
         <DeleteModal hide={toggleDeleteModal} />
       </Modal>
       <Modal hide={toggle} routePath={routePath}>
-        <DetailModal feedId={feedId} nickname={nickname} text={text} imageURLs={imageURLs} hide={toggle} ago={ago} like={like} toggleLike={toggleLike} numOfHearts={numOfHearts} />
+        <DetailModal
+          userId={userId}
+          userImgURL={avatarImage ?? null}
+          feedId={feedId}
+          nickname={nickname}
+          text={text}
+          imageURLs={imageURLs}
+          hide={toggle}
+          ago={ago}
+          like={like}
+          toggleLike={toggleLike}
+          numOfHearts={numOfHearts}
+        />
       </Modal>
     </FeedContainerDiv>
   );

--- a/front/src/components/Feed/FeedContainer.tsx
+++ b/front/src/components/Feed/FeedContainer.tsx
@@ -75,7 +75,7 @@ const FeedContainer = ({ habitatInfo, curHabitatId }: FeedScrollBoxProps) => {
               createdTime={feed.created_at}
               numOfHearts={feed.numOfHearts}
               is_heart={feed.is_heart}
-              avatarImage={feed.user_image_url}
+              avatarImage={feed.user_image_url ?? undefined}
               lazy={lazy}
             />
           ))}

--- a/front/src/components/Header/UserInfo.tsx
+++ b/front/src/components/Header/UserInfo.tsx
@@ -45,7 +45,7 @@ const UserInfo = () => {
   return (
     <UserInfoBlock>
       <div className={'username'}>{userState.data?.nickname}</div>
-      <Avatar size={'30px'} imgSrc={userState.data?.url} />
+      <Avatar size={'30px'} imgSrc={userState.data?.url} userId={userState.data?.userId} />
       <DropBox start={'right'} offset={0} top={parseInt(MagicNumber.HEADER_HEIGHT)} width={150} items={userState.data?.userId === -1 ? dropboxMenu : loginedDropboxMenu}>
         <HamburgerMenuSvg className={'button'} />
       </DropBox>

--- a/front/src/components/User/FeedCell.tsx
+++ b/front/src/components/User/FeedCell.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Modal from '@common/Modal/Modal';
+import useModal from '@common/Modal/useModal';
+import DetailModal from '@components/DetailModal/DetailModal';
+import { Post } from '@src/types/Post';
+import { formatDate } from '@lib/utils/time';
+import { useLike } from '@components/HeartButton/useLike';
+
+interface FeedCellProps {
+  url: string;
+  feedId: number;
+}
+
+const FeedCell = ({ url, feedId }: FeedCellProps) => {
+  const { toggle, isShowing } = useModal();
+  const [feedInfo, setFeedInfo] = useState<Post | null>(null);
+  const [like, toggleLike] = useLike(feedInfo ? feedInfo.is_heart : '', feedId);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    const res: Response = await fetch(`/api/posts/${feedId}`);
+    if (res.ok) {
+      const data: Post = await res.json();
+      setFeedInfo(data);
+      toggle(e);
+    } else {
+      return;
+    }
+  };
+
+  return (
+    <CellDiv onClick={handleClick}>
+      <img src={url} alt={'feed thumbnail'} />
+      <Modal hide={toggle} isShowing={isShowing}>
+        {feedInfo ? (
+          <DetailModal
+            feedId={feedInfo.post_id}
+            ago={formatDate(feedInfo.created_at)}
+            imageURLs={feedInfo.post_contents_urls.split(',')}
+            like={like}
+            nickname={feedInfo.nickname}
+            numOfHearts={feedInfo.numOfHearts}
+            text={feedInfo.human_content}
+            userId={feedInfo.user_id}
+            userImgURL={feedInfo.user_image_url}
+            toggleLike={toggleLike}
+          />
+        ) : null}
+      </Modal>
+    </CellDiv>
+  );
+};
+
+export default FeedCell;
+
+const CellDiv = styled.div`
+  width: 150px;
+  height: 150px;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    cursor: pointer;
+  }
+`;

--- a/front/src/components/User/UserAbout.tsx
+++ b/front/src/components/User/UserAbout.tsx
@@ -18,9 +18,9 @@ const UserAbout = ({ userInfo }: UserAboutProps) => {
       <TextDiv>
         {userInfo ? (
           <>
-            <p className={'nickname'}>{userInfo?.nickname}</p>
-            <p>{userInfo?.speciesId}</p>
-            <p>서식지:{userInfo?.habitatId}</p>
+            <p className={'nickname'}>{userInfo.nickname}</p>
+            <p>{userInfo.speciesId}</p>
+            <p>서식지:{userInfo.habitatId}</p>
           </>
         ) : (
           '존재하지 않는 사용자입니다'

--- a/front/src/components/User/UserAbout.tsx
+++ b/front/src/components/User/UserAbout.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { User } from '@src/types/User';
+import styled from 'styled-components';
+import { flexBox } from '@src/lib/styles/mixin';
+import Avatar from '@common/Avatar/Avatar';
+import { Palette } from '@src/lib/styles/Palette';
+
+interface UserAboutProps {
+  userInfo: User | null;
+}
+
+const UserAbout = ({ userInfo }: UserAboutProps) => {
+  return (
+    <UserAboutDiv>
+      <AvatarDiv>
+        <Avatar imgSrc={userInfo?.content?.url} size={'100%'} />
+      </AvatarDiv>
+      <TextDiv>
+        {userInfo ? (
+          <>
+            <p className={'nickname'}>{userInfo?.nickname}</p>
+            <p>{userInfo?.speciesId}</p>
+            <p>서식지:{userInfo?.habitatId}</p>
+          </>
+        ) : (
+          '존재하지 않는 사용자입니다'
+        )}
+      </TextDiv>
+    </UserAboutDiv>
+  );
+};
+
+export default UserAbout;
+
+const UserAboutDiv = styled.div`
+  ${flexBox('center', 'center', 'row')};
+  gap: 10px;
+  width: 100%;
+  height: 150px;
+  border: 1px solid ${Palette.WHITE};
+  border-radius: 20px;
+  margin-bottom: 20px;
+  /* background-color: aliceblue; */
+`;
+
+const AvatarDiv = styled.div`
+  width: 100px;
+  height: 100px;
+  border-radius: 100%;
+  border: 5px solid white;
+  box-sizing: content-box;
+`;
+
+const TextDiv = styled.div`
+  ${flexBox('center', 'flex-start', 'column')};
+  width: 70%;
+  height: 100%;
+  /* background-color: aqua; */
+  font-size: 20px;
+  .nickname {
+    font-size: 50px;
+  }
+`;

--- a/front/src/components/User/UserFeed.tsx
+++ b/front/src/components/User/UserFeed.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { UserFeeds } from '@src/types/User';
+import styled from 'styled-components';
+import { prettyScroll } from '@src/lib/styles/mixin';
+import MagicNumber from '@src/lib/styles/magic';
+
+interface UserFeedProps {
+  userId: number | undefined;
+}
+
+const UserFeed = ({ userId }: UserFeedProps) => {
+  const [feeds, setFeeds] = useState<UserFeeds>([]);
+  useEffect(() => {
+    const fetchUserFeed = async () => {
+      const res: Response = await fetch(`/api/posts/users/${userId}`);
+      if (res.ok) {
+        const data: UserFeeds = await res.json();
+        setFeeds(data);
+      }
+    };
+    fetchUserFeed();
+  }, [userId]);
+  return (
+    <FeedGridDiv>
+      {feeds.map(({ postId, url }) => (
+        <FeedCell>
+          <img src={url} key={postId} alt={'feed img'} />
+        </FeedCell>
+      ))}
+    </FeedGridDiv>
+  );
+};
+
+export default UserFeed;
+
+const FeedGridDiv = styled.div`
+  ${prettyScroll()};
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  justify-content: space-between;
+  width: 100%;
+  overflow-y: scroll;
+  height: calc(100% - 180px);
+`;
+
+const FeedCell = styled.div`
+  width: 150px;
+  height: 150px;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;

--- a/front/src/components/User/UserFeed.tsx
+++ b/front/src/components/User/UserFeed.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { UserFeeds } from '@src/types/User';
 import styled from 'styled-components';
 import { prettyScroll } from '@src/lib/styles/mixin';
-import MagicNumber from '@src/lib/styles/magic';
+import FeedCell from './FeedCell';
 
 interface UserFeedProps {
   userId: number | undefined;
@@ -10,8 +10,10 @@ interface UserFeedProps {
 
 const UserFeed = ({ userId }: UserFeedProps) => {
   const [feeds, setFeeds] = useState<UserFeeds>([]);
+
   useEffect(() => {
     const fetchUserFeed = async () => {
+      if (!userId) return;
       const res: Response = await fetch(`/api/posts/users/${userId}`);
       if (res.ok) {
         const data: UserFeeds = await res.json();
@@ -23,9 +25,7 @@ const UserFeed = ({ userId }: UserFeedProps) => {
   return (
     <FeedGridDiv>
       {feeds.map(({ postId, url }) => (
-        <FeedCell key={postId}>
-          <img src={url} key={postId} alt={'feed img'} />
-        </FeedCell>
+        <FeedCell key={postId} feedId={postId} url={url} />
       ))}
     </FeedGridDiv>
   );
@@ -41,14 +41,4 @@ const FeedGridDiv = styled.div`
   width: 100%;
   overflow-y: scroll;
   height: calc(100% - 180px);
-`;
-
-const FeedCell = styled.div`
-  width: 150px;
-  height: 150px;
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
 `;

--- a/front/src/components/User/UserFeed.tsx
+++ b/front/src/components/User/UserFeed.tsx
@@ -23,7 +23,7 @@ const UserFeed = ({ userId }: UserFeedProps) => {
   return (
     <FeedGridDiv>
       {feeds.map(({ postId, url }) => (
-        <FeedCell>
+        <FeedCell key={postId}>
           <img src={url} key={postId} alt={'feed img'} />
         </FeedCell>
       ))}

--- a/front/src/components/_common/Avatar/Avatar.tsx
+++ b/front/src/components/_common/Avatar/Avatar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 export const DEFAULT_AVATAR = `/default_avatar.png`;
 
 const AvatarBlock = styled.div<Omit<AvatarProps, 'imgSrc'>>`
@@ -16,12 +17,15 @@ const AvatarBlock = styled.div<Omit<AvatarProps, 'imgSrc'>>`
 interface AvatarProps {
   imgSrc?: string;
   size: string;
+  userId?: number;
 }
 
-const Avatar = ({ imgSrc = DEFAULT_AVATAR, size }: AvatarProps) => {
+const Avatar = ({ imgSrc = DEFAULT_AVATAR, size, userId }: AvatarProps) => {
   return (
     <AvatarBlock size={size}>
-      <img src={imgSrc} alt="아바타 이미지" />
+      <Link to={userId && userId !== -1 ? `/user/${userId}` : ''}>
+        <img src={imgSrc} alt="아바타 이미지" />
+      </Link>
     </AvatarBlock>
   );
 };

--- a/front/src/pages/UserPage.tsx
+++ b/front/src/pages/UserPage.tsx
@@ -1,7 +1,68 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Header from '@src/components/Header/Header';
+import styled from 'styled-components';
+import { flexBox } from '@src/lib/styles/mixin';
+import { Palette } from '@src/lib/styles/Palette';
+import useHabitatInfo from '@src/hooks/useHabitatInfo';
+import { useParams } from 'react-router';
+import { User } from '@src/types/User';
+import UserAbout from '@src/components/User/UserAbout';
+import UserFeed from '@src/components/User/UserFeed';
+import MagicNumber from '@src/lib/styles/magic';
+
+const DEFAULT_HABITAT_ID = 2;
 
 const UserPage = () => {
-  return <div>user page</div>;
+  const param: { id: string } = useParams();
+  const [userInfo, setUserInfo] = useState<User | null>(null);
+  const { habitatInfo } = useHabitatInfo(userInfo?.habitatId ?? DEFAULT_HABITAT_ID);
+
+  useEffect(() => {
+    console.log(param);
+    const fetchUserInfo = async () => {
+      const res: Response = await fetch(`/api/users/${param.id}`);
+      if (res.ok) {
+        const data: User = await res.json();
+        console.log(data);
+        setUserInfo(data);
+      } else {
+        console.log(res);
+      }
+    };
+
+    try {
+      fetchUserInfo();
+    } catch (e) {
+      console.log(e);
+    }
+  }, [param]);
+  return (
+    <UserPageDiv>
+      <Header habitatInfo={habitatInfo} />
+      <ContentDiv color={habitatInfo?.habitat.color}>
+        <UserAbout userInfo={userInfo} />
+        <UserFeed userId={userInfo?.id} />
+      </ContentDiv>
+    </UserPageDiv>
+  );
 };
 
 export default UserPage;
+
+const UserPageDiv = styled.div`
+  ${flexBox(null, null, 'column')};
+  overflow: hidden;
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  background-color: ${Palette.BACKGROUND_GRAY};
+`;
+
+const ContentDiv = styled.div<{ color: string | undefined }>`
+  width: ${MagicNumber.FEED_SECTION_WIDTH};
+  height: calc(100% - ${MagicNumber.HEADER_HEIGHT});
+  position: relative;
+  background-color: ${(props) => props.color ?? Palette.GRAY};
+  margin: auto;
+  padding: 20px;
+`;

--- a/front/src/types/User.ts
+++ b/front/src/types/User.ts
@@ -1,0 +1,22 @@
+interface Content {
+  id: number;
+  url: string;
+  mimeType: string;
+}
+
+export interface User {
+  id: number;
+  username: string;
+  nickname: string;
+  habitatId: number | null;
+  speciesId: null | number;
+  content: null | Content;
+}
+
+interface UserFeed {
+  postId: number;
+  url: string;
+  numOfHearts: number;
+}
+
+export type UserFeeds = UserFeed[];


### PR DESCRIPTION
### 작업 내역
---
- [x] 유저 페이지 구현
- [x] Avatar 컴포넌트 클릭시 유저 페이지로 라우팅
- [x] 글수정/삭제 드롭박스 자신의 피드에만 나타나도록 수정
- [x] 글삭제/글수정 api 연결 시도
- [x] 유저 페이지에서 상세보기 모달 연결

### 고민 및 해결
---
1. 유저페이지에서 해더의 서식지모달이 작동하지 않는다. `/` 경로를 기준으로 모달 라우팅이 되고 있는것 같은데 `/user` 에서는 작동하지 않는 것 같다. 
2. 마찬가지로 유저페이지에서 피드를 눌렀을때 나타나는 상세 모달을 라우팅 시도하였으나 실패하였다. 일단은 라우팅 없이 모달만 뜨도록 하였다.
3. 게시글 수정 로직이 백앤드에서는 `contentIDs` 를 받는 것으로 보아 기존에 업로드된 컨텐츠들에서 삭제만 가능한 로직인 것 같은데 글쓰기 모달을 재사용하기 위해서는 글쓰기 모달 POST 요청과 동일하게 처리되어야 한다. 
4. 글수정 모달을 글쓰기 모달의 재사용으로 구현하기 위해 url을 file 객체로 변환하여야 했는데 이 과정에서 object storage 주소로 fetch 요청을 보낼때 cors 애러가 발생하였다. 
5. 글삭제 api의 경우 정상적으로 200번대 응답을 받았음에도 실제로는 삭제되지 않았다. 

### (필요시) 데모 이미지
---
![demo](https://user-images.githubusercontent.com/63776725/143068757-e5c9a383-2743-4273-8464-23b75bcc9c30.gif)
