### PR TITLE
[W5][D4][다람이] 게시글 조회 쿼리 성능 개선

### DIFF
--- a/back/src/post/post.service.ts
+++ b/back/src/post/post.service.ts
@@ -109,10 +109,10 @@ export class PostService {
     , (select count(*) from comment where post_id = p.post_id) as numOfComments
     , (select count(*) from heart where post_id = p.post_id and user_id = ?) as is_heart
     from post p
-    inner join user u on u.user_id = p.user_id
+    straight_join user u on u.user_id = p.user_id
     left join contents c on c.contents_id = u.contents_id
-    inner join post_contents pc on pc.post_id = p.post_id
-    inner join contents pcc on pc.contents_id = pcc.contents_id
+    straight_join post_contents pc on pc.post_id = p.post_id
+    straight_join contents pcc on pc.contents_id = pcc.contents_id
     `;
   }
 


### PR DESCRIPTION
### 작업 내역
---
- [ ] 게시글 조회 쿼리 성능 개선

### 고민 및 해결
---
1. inner join에서 straight join으로 변경해서 쿼리 옵티마이져가 드라이빙 테이블을 group by, order by 테이블인 포스트 테이블로 유지하도록 하였다.

### (필요시) 데모 이미지
---
