### PR TITLE
[잔업][다람이] 각종 버그 해결 / 중복 제거 / 상세보기 댓글 로직 연결

### DIFF
--- a/front/src/components/DeleteModal/DeleteModal.tsx
+++ b/front/src/components/DeleteModal/DeleteModal.tsx
@@ -5,6 +5,7 @@ import { flexBox } from '@lib/styles/mixin';
 import { ToggleHandler } from '@common/Modal/useModal';
 import { useUserState } from '@src/contexts/UserContext';
 import { useHistory } from 'react-router';
+import { getAuthOption } from '@src/lib/utils/fetch';
 
 interface DeleteModalProps {
   hide: ToggleHandler;
@@ -22,7 +23,7 @@ const DeleteModal = ({ hide, feedId }: DeleteModalProps) => {
       return;
     }
     setDelete(true);
-    const res: Response = await fetch(`/api/posts/${feedId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${userState.data.accessToken}` } });
+    const res: Response = await fetch(`/api/posts/${feedId}`, getAuthOption('DELETE', userState.data.accessToken));
     console.log(res);
     if (res.ok) {
       history.go(0);

--- a/front/src/components/DetailModal/Comment.tsx
+++ b/front/src/components/DetailModal/Comment.tsx
@@ -23,7 +23,7 @@ interface CommentProps {
 
 type Mode = 'edit' | 'delete' | 'normal';
 
-const Comment = ({ nickname, comment, avatar, userId, toggleEditMode, createdAt, bottomRef }: CommentProps) => {
+const Comment = ({ nickname, comment, avatar, userId, toggleEditMode, createdAt, bottomRef, commentId }: CommentProps) => {
   const [mode, setMode] = useState<Mode>('normal');
   const { data } = useUserState();
   const handleEditBtnClick = () => {

--- a/front/src/components/DetailModal/Comment.tsx
+++ b/front/src/components/DetailModal/Comment.tsx
@@ -23,7 +23,7 @@ interface CommentProps {
 
 type Mode = 'edit' | 'delete' | 'normal';
 
-const Comment = ({ nickname, comment, avatar, userId, toggleEditMode, createdAt, bottomRef, commentId }: CommentProps) => {
+const Comment = ({ nickname, comment, avatar, userId, toggleEditMode, createdAt, bottomRef }: CommentProps) => {
   const [mode, setMode] = useState<Mode>('normal');
   const { data } = useUserState();
   const handleEditBtnClick = () => {
@@ -46,7 +46,7 @@ const Comment = ({ nickname, comment, avatar, userId, toggleEditMode, createdAt,
       <TextDiv>
         <TextHeader>
           <span>{nickname}</span>
-          <span className={'time'}>{formatDate(createdAt)} 전</span>
+          <span className={'time'}>{formatDate(createdAt)}</span>
         </TextHeader>
         <p>{comment}</p>
       </TextDiv>

--- a/front/src/components/DetailModal/Comment.tsx
+++ b/front/src/components/DetailModal/Comment.tsx
@@ -10,6 +10,67 @@ import { Palette } from '@src/lib/styles/Palette';
 import { useUserState } from '@src/contexts/UserContext';
 import { formatDate } from '@lib/utils/time';
 
+interface CommentProps {
+  nickname: string;
+  comment: string;
+  avatar: string | null;
+  userId: number;
+  createdAt: string;
+  commentId: number;
+  toggleEditMode: (text: string) => void;
+  bottomRef?: (node: HTMLDivElement) => void;
+}
+
+type Mode = 'edit' | 'delete' | 'normal';
+
+const Comment = ({ nickname, comment, avatar, userId, toggleEditMode, createdAt, bottomRef, commentId }: CommentProps) => {
+  const [mode, setMode] = useState<Mode>('normal');
+  const { data } = useUserState();
+  const handleEditBtnClick = () => {
+    setMode(mode === 'edit' ? 'normal' : 'edit');
+    toggleEditMode(comment);
+  };
+
+  const handleDeleteBtnClick = () => {
+    if (mode === 'edit') toggleEditMode('');
+    setMode('delete');
+  };
+
+  const handleConfirmCancel = () => {
+    setMode('normal');
+  };
+
+  return (
+    <CommentDiv isEdited={mode === 'edit'} ref={bottomRef}>
+      <Avatar size={'30px'} imgSrc={avatar} />
+      <TextDiv>
+        <TextHeader>
+          <span>{nickname}</span>
+          <span className={'time'}>{formatDate(createdAt)} 전</span>
+        </TextHeader>
+        <p>{comment}</p>
+      </TextDiv>
+      {data?.userId === userId && (
+        <ControlDiv>
+          <EditSvg onClick={handleEditBtnClick} />
+          <DeleteSvg onClick={handleDeleteBtnClick} />
+        </ControlDiv>
+      )}
+      {mode === 'delete' && (
+        <DeleteHoverDiv>
+          <span>삭제하시겠습니까?</span>
+          <div>
+            <CheckBtnSvg className={'button'} />
+            <CancelBtnSvg className={'button'} onClick={handleConfirmCancel} />
+          </div>
+        </DeleteHoverDiv>
+      )}
+    </CommentDiv>
+  );
+};
+
+export default Comment;
+
 const CommentDiv = styled.div<{ isEdited: boolean }>`
   ${flexBox('flex-start', 'flex-start')};
   width: 100%;
@@ -76,63 +137,3 @@ const TextHeader = styled.div`
     margin-right: 10px;
   }
 `;
-
-interface CommentProps {
-  nickname: string;
-  comment: string;
-  avatar: string | null;
-  userId: number;
-  createdAt: string;
-  toggleEditMode: (text: string) => void;
-}
-
-type Mode = 'edit' | 'delete' | 'normal';
-
-const Comment = ({ nickname, comment, avatar, userId, toggleEditMode, createdAt }: CommentProps) => {
-  const [mode, setMode] = useState<Mode>('normal');
-  const { data } = useUserState();
-  const handleEditBtnClick = () => {
-    setMode(mode === 'edit' ? 'normal' : 'edit');
-    // setEditMode(!editMode);
-    toggleEditMode(comment);
-  };
-
-  const handleDeleteBtnClick = () => {
-    if (mode === 'edit') toggleEditMode('');
-    setMode('delete');
-  };
-
-  const handleConfirmCancel = () => {
-    setMode('normal');
-  };
-
-  return (
-    <CommentDiv isEdited={mode === 'edit'}>
-      <Avatar size={'30px'} imgSrc={avatar} />
-      <TextDiv>
-        <TextHeader>
-          <span>{nickname}</span>
-          <span className={'time'}>{formatDate(createdAt)} 전</span>
-        </TextHeader>
-        <p>{comment}</p>
-      </TextDiv>
-      {data?.userId === userId && (
-        <ControlDiv>
-          <EditSvg onClick={handleEditBtnClick} />
-          <DeleteSvg onClick={handleDeleteBtnClick} />
-        </ControlDiv>
-      )}
-      {mode === 'delete' && (
-        <DeleteHoverDiv>
-          <span>삭제하시겠습니까?</span>
-          <div>
-            <CheckBtnSvg className={'button'} />
-            <CancelBtnSvg className={'button'} onClick={handleConfirmCancel} />
-          </div>
-        </DeleteHoverDiv>
-      )}
-    </CommentDiv>
-  );
-};
-
-export default Comment;

--- a/front/src/components/DetailModal/CommentForm.tsx
+++ b/front/src/components/DetailModal/CommentForm.tsx
@@ -2,6 +2,9 @@ import { flexBox } from '@src/lib/styles/mixin';
 import { Palette } from '@src/lib/styles/Palette';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import { getAuthOption } from '@lib/utils/fetch';
+import { useUserState } from '@src/contexts/UserContext';
+import { CommentAction } from './useCommentList';
 
 const UserForm = styled.form`
   ${flexBox('flex-start', 'center', 'row')};
@@ -31,11 +34,13 @@ interface CommentFormProps {
   editMode: boolean;
   setInputText: React.Dispatch<React.SetStateAction<string>>;
   inputText: string;
+  commentDispatch: React.Dispatch<CommentAction>;
 }
 
-const CommentForm = ({ editMode, inputText, setInputText }: CommentFormProps) => {
+const CommentForm = ({ editMode, inputText, setInputText, commentDispatch, feedId }: CommentFormProps) => {
   const [isActive, setActive] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const userState = useUserState();
   const handleInputChange = () => {
     const $input = inputRef.current;
     if ($input) setInputText($input.value);
@@ -49,8 +54,36 @@ const CommentForm = ({ editMode, inputText, setInputText }: CommentFormProps) =>
     }
   }, [inputText]);
 
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isActive) {
+      return;
+    }
+    if (editMode) {
+      return;
+    } else {
+      const addComment = async () => {
+        const data = {
+          post_id: feedId,
+          content: inputRef.current?.value,
+        };
+        const res: Response = await fetch(`/api/comments`, getAuthOption('POST', userState.data?.accessToken, data));
+        if (res.ok) {
+          commentDispatch({ type: 'REFRESH' });
+        } else {
+          console.log(res.status);
+        }
+      };
+      try {
+        addComment();
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  };
+
   return (
-    <UserForm>
+    <UserForm onSubmit={handleSubmit}>
       <UserInput editMode={editMode} onChange={handleInputChange} ref={inputRef} placeholder={'댓글을 입력하세요.'} required />
       <SubmitBtn type={'submit'} isActive={isActive}>
         {isActive ? 'OK!' : 'X'}

--- a/front/src/components/DetailModal/CommentList.tsx
+++ b/front/src/components/DetailModal/CommentList.tsx
@@ -1,10 +1,11 @@
 import { prettyScroll } from '@src/lib/styles/mixin';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import Comment from './Comment';
 import { Comments } from '@src/types/Comment';
 import { useElementRef } from '@hooks/useElementRef';
 import useScrollObserver from '@hooks/useScrollObserver';
+import { CommentAction, CommentState } from './useCommentList';
 
 const ScrollBox = styled.div`
   ${prettyScroll()};
@@ -17,41 +18,65 @@ const ScrollBox = styled.div`
 interface CommentListProps {
   feedId: number;
   toggleEditMode: (text: string) => void;
+  commentState: CommentState;
+  commentDispatch: React.Dispatch<CommentAction>;
 }
 
-const CommentList = ({ feedId, toggleEditMode }: CommentListProps) => {
-  const [comments, setComments] = useState<Comments>([]);
-  const [lastComment, setLastComment] = useState(0);
+const CommentList = ({ feedId, toggleEditMode, commentState, commentDispatch }: CommentListProps) => {
+  const { commentList: comments, lastComment } = commentState;
+  async function getComment() {
+    const response: Response = await fetch(`/api/comments/cursor/?limit=10&postId=${feedId}${lastComment !== -1 ? `&lastId=${lastComment}` : ''}`);
+    const commentsData: Comments = await response.json();
+
+    if (lastComment === -1) {
+      commentDispatch({ type: 'INIT_COMMENT_LIST', data: commentsData });
+      return;
+    }
+    commentDispatch({ type: 'UPDATE_COMMENT_LIST', data: commentsData });
+  }
 
   useEffect(() => {
+    if (lastComment === -1) {
+      getComment();
+      return;
+    } else if (!comments.length || lastComment === 0) return;
     getComment();
-
-    async function getComment() {
-      const response: Response = await fetch(`/api/comments/cursor/?limit=10&postId=${feedId}${lastComment ? `&lastId=${lastComment}` : ''}`);
-      const commentsData: Comments = await response.json();
-
-      setComments((comments) => [...comments, ...commentsData]);
-    }
   }, [lastComment]);
 
   const [observerElement, observerRef] = useElementRef();
 
   const options = { root: observerElement, rootMargin: '150px', threshold: 1.0 };
 
-  const handleObserver = (entries: any) => {
-    const target = entries[0];
-    if (target.isIntersecting && comments.length) {
-      setLastComment(comments[comments.length - 1].id);
-    }
-  };
+  const handleObserver = useCallback(
+    (entries: any) => {
+      const target = entries[0];
+      if (target.isIntersecting && comments.length) {
+        commentDispatch({ type: 'UPDATE_LAST_COMMENT', data: comments[comments.length - 1].id });
+      }
+    },
+    [comments]
+  );
   const bottomRef = useScrollObserver(handleObserver, options);
 
   return (
     <ScrollBox ref={observerRef}>
-      {comments.map(({ user, content, userId, id, createdAt }) => (
-        <Comment toggleEditMode={toggleEditMode} userId={userId} key={id} nickname={user.nickname} comment={content} avatar={user.content?.url} createdAt={createdAt} />
-      ))}
-      <div ref={bottomRef} />
+      {comments.map(({ user, content, userId, id, createdAt }, idx) => {
+        if (idx === comments.length - 1)
+          return (
+            <Comment
+              toggleEditMode={toggleEditMode}
+              commentId={id}
+              userId={userId}
+              key={id}
+              nickname={user.nickname}
+              comment={content}
+              avatar={user.content?.url}
+              createdAt={createdAt}
+              bottomRef={bottomRef}
+            />
+          );
+        return <Comment toggleEditMode={toggleEditMode} commentId={id} userId={userId} key={id} nickname={user.nickname} comment={content} avatar={user.content?.url} createdAt={createdAt} />;
+      })}
     </ScrollBox>
   );
 };

--- a/front/src/components/DetailModal/DetailModal.tsx
+++ b/front/src/components/DetailModal/DetailModal.tsx
@@ -10,6 +10,7 @@ import CommentList from './CommentList';
 import CommentForm from './CommentForm';
 import HeartSection from './HeartSection';
 import { LikeProps } from '@components/HeartButton/useLike';
+import useCommentList from './useCommentList';
 
 interface DetailModalProps extends LikeProps {
   hide?: ToggleHandler;
@@ -26,6 +27,7 @@ interface DetailModalProps extends LikeProps {
 const DetailModal = ({ feedId, userId, userImgURL, imageURLs, nickname, text, ago, like, toggleLike, numOfHearts }: DetailModalProps) => {
   const [editMode, setEditMode] = useState(false);
   const [inputText, setInputText] = useState('');
+  const [commentState, commentDispatch] = useCommentList();
   const toggleEditMode = (text: string) => {
     if (editMode) {
       setEditMode(false);
@@ -61,9 +63,9 @@ const DetailModal = ({ feedId, userId, userImgURL, imageURLs, nickname, text, ag
             non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`}
           </p>
         </FeedInfoDiv>
-        <CommentList toggleEditMode={toggleEditMode} feedId={feedId} />
+        <CommentList commentState={commentState} commentDispatch={commentDispatch} toggleEditMode={toggleEditMode} feedId={feedId} />
         <HeartSection like={like} toggleLike={toggleLike} numOfHearts={numOfHearts} />
-        <CommentForm inputText={inputText} setInputText={setInputText} editMode={editMode} feedId={feedId} />
+        <CommentForm inputText={inputText} commentDispatch={commentDispatch} setInputText={setInputText} editMode={editMode} feedId={feedId} />
       </CommunicateDiv>
     </DetailModalDiv>
   );

--- a/front/src/components/DetailModal/useCommentList.ts
+++ b/front/src/components/DetailModal/useCommentList.ts
@@ -1,0 +1,39 @@
+import { Comments } from '@src/types/Comment';
+import React, { useReducer } from 'react';
+
+export interface CommentState {
+  commentList: Comments;
+  lastComment: number;
+}
+
+const initCommentState: CommentState = {
+  commentList: [],
+  lastComment: -1,
+};
+
+export interface CommentAction {
+  type: 'UPDATE_LAST_COMMENT' | 'UPDATE_COMMENT_LIST' | 'REFRESH' | 'INIT_COMMENT_LIST';
+  data?: Comments | number;
+}
+
+const reducer = (state: CommentState, action: CommentAction): CommentState => {
+  switch (action.type) {
+    case 'UPDATE_COMMENT_LIST':
+      return { ...state, commentList: [...state.commentList, ...(action.data as Comments)] };
+    case 'UPDATE_LAST_COMMENT':
+      return { ...state, lastComment: action.data as number };
+    case 'REFRESH':
+      return initCommentState;
+    case 'INIT_COMMENT_LIST':
+      return { commentList: action.data as Comments, lastComment: 0 };
+    default:
+      throw new Error('unhandled action');
+  }
+};
+
+const useCommentList = (): [CommentState, React.Dispatch<CommentAction>] => {
+  const [state, dispatch] = useReducer(reducer, initCommentState);
+  return [state, dispatch];
+};
+
+export default useCommentList;

--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -36,7 +36,7 @@ export interface FeedProps {
   lazy?: (node: HTMLDivElement) => void;
 }
 
-const Feed = ({ feedId, userId, nickname, imageURLs, contentIds, humanText, animalText, lazy, createdTime, numOfHearts, is_heart, avatarImage, numOfComments }: FeedProps) => {
+const Feed = ({ feedId, userId, nickname, imageURLs, contentIds, humanText, animalText, lazy, createdTime, is_heart, avatarImage, numOfComments }: FeedProps) => {
   const { isShowing: isDeleteShowing, toggle: toggleDeleteModal } = useModal();
   const { isShowing: isEditShowing, toggle: toggleEditModal } = useModal();
   const [like, toggleLike] = useLike(is_heart, feedId);
@@ -74,7 +74,7 @@ const Feed = ({ feedId, userId, nickname, imageURLs, contentIds, humanText, anim
         />
         <span>{numOfComments}</span>
         <TranslateBtnSvg className={'button translate'} onClick={() => setTranslate(!isTranslate)} />
-        <span className="time">{ago} 전</span>
+        <span className="time">{ago}</span>
       </FeedInfoDiv>
       <FeedTextDiv>{isTranslate ? humanText : animalText}</FeedTextDiv>
       <Modal isShowing={isDeleteShowing} hide={toggleDeleteModal}>

--- a/front/src/components/Feed/useDetailFeed.ts
+++ b/front/src/components/Feed/useDetailFeed.ts
@@ -24,7 +24,7 @@ const useDetailFeed = (feeds: Posts) => {
     async function getFeed(id: number) {
       const response: Response = await fetch(`/api/posts/${id}`);
       const detailFeed: Post = await response.json();
-      detailFeed.contents_url_array = detailFeed.post_contents_urls.split(',');
+      detailFeed.contents_url_array = detailFeed.post_contents_urls.split(',').map((url) => url.replace('.webp', '-feed.webp'));
       setDetail(detailFeed);
       return detailFeed;
     }

--- a/front/src/components/Habitat/HabitatPreview.tsx
+++ b/front/src/components/Habitat/HabitatPreview.tsx
@@ -5,7 +5,7 @@ import useHabitatInfo from '@hooks/useHabitatInfo';
 import { flexBox } from '@lib/styles/mixin';
 import MagicNumber from '@lib/styles/magic';
 import { Palette } from '@lib/styles/Palette';
-import { compareTime } from '@lib/utils/time';
+import { formatDate } from '@lib/utils/time';
 import Loading from '@common/Indicator/Loading';
 import Warning from '@common/Indicator/Warning';
 
@@ -51,7 +51,7 @@ const HabitatPreview = ({ side, habitat, onClick }: HabitatPreviewProps) => {
                   <DetailDiv radius={radius}>
                     <p>{habitatInfo.userCnt} 마리의 동물들</p>
                     <p>{habitatInfo.postCnt}개의 게시글</p>
-                    <p>최근 활동 {compareTime(new Date(), new Date(habitatInfo.lastActTime))}</p>
+                    <p>최근 활동 {formatDate(habitatInfo.lastActTime)}</p>
                   </DetailDiv>
                   <TitleDiv radius={radius}>
                     <p className="habitat_king">우두머리: {habitatInfo.leader?.nickName}</p>

--- a/front/src/components/Write/WriteModal.tsx
+++ b/front/src/components/Write/WriteModal.tsx
@@ -10,6 +10,7 @@ import { flexBox, boxShadow } from '@lib/styles/mixin';
 import { ToggleHandler } from '@common/Modal/useModal';
 import { useUserState } from '@src/contexts/UserContext';
 import { useHistory } from 'react-router';
+import { getAuthOption } from '@lib/utils/fetch';
 
 interface InitState {
   contents: string[];
@@ -70,8 +71,8 @@ const WriteModal = ({ hide, initState }: WriteModalProps) => {
       }
       let response: Response;
       if (initState) {
-        response = await fetch(`/api/posts/${initState.feedId}`, { method: 'PATCH', headers: { Authorization: `Bearer ${userState.data.accessToken}` }, body: data });
-      } else response = await fetch(form.action, { method: 'POST', headers: { Authorization: `Bearer ${userState.data.accessToken}` }, body: data });
+        response = await fetch(`/api/posts/${initState.feedId}`, getAuthOption('PATCH', userState.data.accessToken, data));
+      } else response = await fetch(form.action, getAuthOption('POST', userState.data.accessToken, data));
 
       const result = await response.json();
 

--- a/front/src/hooks/useValidateUser.ts
+++ b/front/src/hooks/useValidateUser.ts
@@ -1,5 +1,6 @@
 import { useUserDispatch, User, UserState } from '@src/contexts/UserContext';
 import { useEffect } from 'react';
+import { getAuthOption } from '@lib/utils/fetch';
 
 const useValidateUser = (userState: UserState) => {
   const userDispatch = useUserDispatch();
@@ -7,7 +8,7 @@ const useValidateUser = (userState: UserState) => {
     const accessToken = localStorage.getItem('access_token');
     if (!accessToken || accessToken === 'undefined' || userState.loading || userState.data?.userId !== -1) return;
     const validFetch = async () => {
-      const res: Response = await fetch(`/api/users/info`, { method: 'GET', headers: { Authorization: `Bearer ${accessToken}` } });
+      const res: Response = await fetch(`/api/users/info`, getAuthOption('GET', accessToken));
       if (res.ok) {
         const data = await res.json();
         const newState: User = {

--- a/front/src/lib/utils/fetch.ts
+++ b/front/src/lib/utils/fetch.ts
@@ -1,0 +1,5 @@
+type HTTPMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
+
+export const getAuthOption = (method: HTTPMethod, accessToken: string | undefined, data?: any): RequestInit => {
+  return { method: method, headers: { Authorization: `Bearer ${accessToken}` }, body: data };
+};

--- a/front/src/lib/utils/time.ts
+++ b/front/src/lib/utils/time.ts
@@ -8,6 +8,9 @@ export const compareTime = (from: Date, to: Date) => {
 };
 
 export const formatDate = (sqlDate: string) => {
+  if (!sqlDate.length) {
+    return '내역 없음';
+  }
   const [date, time] = sqlDate.split('T');
   const [YYYY, MM, DD] = date.split('-');
   const [hh, mm] = time.split(':');
@@ -21,7 +24,7 @@ export const formatDate = (sqlDate: string) => {
   // 가장 큰 단위의 날짜를 반환해줌 ex)1년 전, 5개월 전, 3주 전, 30초 전...
   const pastDate = pipe(divisionYear, divisionMonth, divisionWeek, divisionDay, divisionHour, divisionMin)(second);
 
-  return typeof pastDate === 'number' ? `${pastDate}초 ` : `${pastDate[1]} ${pastDate[0]}`;
+  return typeof pastDate === 'number' ? `${pastDate}초 전` : `${pastDate[1]} ${pastDate[0]} 전`;
 };
 
 const divisionYear = (second: any): any => {

--- a/front/src/types/Habitat.ts
+++ b/front/src/types/Habitat.ts
@@ -23,5 +23,5 @@ export interface HabitatInfo {
   userCnt: number;
   postCnt: number;
   recentUsers: RecentUserInfo[];
-  lastActTime: Date;
+  lastActTime: string;
 }


### PR DESCRIPTION
### 작업 내역
---
- [x] 서식지 시간 버그 해결
- [x] 상세보기 모달 버벅임 해결
- [x] access token 관련 fetch option 중복 구현 제거
- [x] 상세보기 댓글 무한스크롤 버그 해결
- [x] 댓글 작성 api 연결

### 고민 및 해결
---
1. 상세보기 모달 버벅임은 상세모달을 그릴때 데이터를 fetch 해서 그리는 경우 img 를 feed 이미지가 아닌 원본 이미지를 사용하여서 발생하는 문제였다.
2. access token 옵션을 만드는 함수를 유틸에 구현해두었다.
3. 댓글을 작성하면 화면 전체를 새로고침하지않고 댓글 리스트 부분만 새로고침하려고 상태 관리 로직을 state에서 reduce 로 변경하였다.
4. 무한스크롤이 마지막에 도달해서 계속 화면 안에 있을때 반복적으로 callback 함수가 발생하는 버그를 수정하였다. 
5. 댓글 api 연결을 시도하였는데 500에러가 발생하였다. 
![image](https://user-images.githubusercontent.com/63776725/143597653-b2ff5dad-524f-4103-99f4-09c8e08be8fa.png)
추가적으로 댓글 수정,삭제 api에 access token 인증 로직이 빠져있다. 이슈등록해두었음.

### (필요시) 데모 이미지
---
