### PR TITLE
[잔업][스폰지밥] 이미지 버그수정 및 인증로직 수정

### DIFF
--- a/back/config/database.config.ts
+++ b/back/config/database.config.ts
@@ -13,7 +13,7 @@ const databaseConfig: TypeOrmModuleOptions = {
   entities: [__dirname + '/../**/*.entity{.ts,.js}'],
   // autoLoadEntities: true,
   synchronize: false,
-  logging: true,
+  logging: process.env.NODE_ENV === 'db_dev',
   timezone: '+00:00',
 };
 

--- a/back/config/s3.config.ts
+++ b/back/config/s3.config.ts
@@ -14,76 +14,77 @@ const s3 = new AWS.S3({
   },
 });
 
-export const multerUserOption = () => {
-  const uuidKey = uuidv1().toString();
-
-  return {
-    storage: multerS3({
-      s3,
-      shouldTransform: true,
-      transforms: [
-        {
-          id: 'origin',
-          key: function (request, file, cb) {
-            cb(null, `${uuidKey}.webp`);
-          },
-          transform: function (req, file, cb) {
-            cb(null, sharp({ animated: true }).webp({ quality: 90 }));
-          },
+export const multerUserOption = {
+  storage: multerS3({
+    s3,
+    shouldTransform: true,
+    key: function (req, file, cb) {
+      file.__uuid__ = uuidv1().toString(); // ***
+      cb(null, file.__uuid__);
+    },
+    transforms: [
+      {
+        id: 'origin',
+        key: function (request, file, cb) {
+          cb(null, `${file.__uuid__}.webp`);
         },
-        {
-          id: 'profile',
-          key: function (request, file, cb) {
-            cb(null, `${uuidKey}-profile.webp`);
-          },
-          transform: function (req, file, cb) {
-            cb(null, sharp().resize({ width: 100, height: 100 }).webp({ quality: 80 }));
-          },
+        transform: function (req, file, cb) {
+          cb(null, sharp({ animated: true }).webp({ quality: 90 }));
         },
-      ],
-      bucket: 'spongebob-bucket',
-      acl: 'public-read',
-      contentType: function (req, file, cb) {
-        cb(null, 'image/webp');
       },
-    }),
-  };
+      {
+        id: 'profile',
+        key: function (request, file, cb) {
+          cb(null, `${file.__uuid__}-profile.webp`);
+        },
+        transform: function (req, file, cb) {
+          cb(null, sharp().resize({ width: 100, height: 100 }).webp({ quality: 80 }));
+        },
+      },
+    ],
+    bucket: 'spongebob-bucket',
+    acl: 'public-read',
+    contentType: function (req, file, cb) {
+      cb(null, 'image/webp');
+    },
+  }),
 };
 
-export const multerTransFormOption = () => {
-  const uuidKey = uuidv1().toString();
-  return {
-    storage: multerS3({
-      s3,
-      shouldTransform: true,
-      transforms: [
-        {
-          id: 'origin',
-          key: function (request, file, cb) {
-            cb(null, `${uuidKey}.webp`);
-          },
-          transform: function (req, file, cb) {
-            cb(null, sharp({ animated: true }).webp({ quality: 90 }));
-          },
+export const multerTransFormOption = {
+  storage: multerS3({
+    s3,
+    shouldTransform: true,
+    key: function (req, file, cb) {
+      file.__uuid__ = uuidv1().toString(); // ***
+      cb(null, file.__uuid__);
+    },
+    transforms: [
+      {
+        id: 'origin',
+        key: function (request, file, cb) {
+          cb(null, `${file.__uuid__}.webp`);
         },
-        {
-          id: 'feed',
-          key: function (request, file, cb) {
-            cb(null, `${uuidKey}-feed.webp`);
-          },
-          transform: function (req, file, cb) {
-            cb(
-              null,
-              sharp({ animated: true }).resize({ width: 470, height: 500 }).webp({ quality: 80 })
-            );
-          },
+        transform: function (req, file, cb) {
+          cb(null, sharp({ animated: true }).webp({ quality: 90 }));
         },
-      ],
-      bucket: 'spongebob-bucket',
-      acl: 'public-read',
-      contentType: function (req, file, cb) {
-        cb(null, 'image/webp');
       },
-    }),
-  };
+      {
+        id: 'feed',
+        key: function (request, file, cb) {
+          cb(null, `${file.__uuid__}-feed.webp`);
+        },
+        transform: function (req, file, cb) {
+          cb(
+            null,
+            sharp({ animated: true }).resize({ width: 470, height: 500 }).webp({ quality: 80 })
+          );
+        },
+      },
+    ],
+    bucket: 'spongebob-bucket',
+    acl: 'public-read',
+    contentType: function (req, file, cb) {
+      cb(null, 'image/webp');
+    },
+  }),
 };

--- a/back/src/comments/comments.controller.ts
+++ b/back/src/comments/comments.controller.ts
@@ -24,13 +24,12 @@ import { Comment } from './entities/comment.entity';
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}
 
-  @ApiBearerAuth('access-token')
   @Post() //댓글 추가
-  @UseGuards(AuthGuard('jwt'))
   @ApiOperation({
     summary: '댓글 추가 API',
     description: '게시물에 댓글을 추가한다.',
   })
+  @ApiBearerAuth('access-token')
   @UseGuards(AuthGuard('jwt'))
   @ApiCreatedResponse({ description: '댓글 생성', type: Comment })
   create(@Body() createCommentDto: CreateCommentDto, @Req() req) {
@@ -42,6 +41,7 @@ export class CommentsController {
     summary: '댓글 수정 API',
     description: '게시물 댓글을 수정한다.',
   })
+  @ApiBearerAuth('access-token')
   @UseGuards(AuthGuard('jwt'))
   update(
     @Param('commentId', ParseIntPipe) commentId: number,
@@ -56,6 +56,7 @@ export class CommentsController {
     summary: '댓글 삭제 API',
     description: '게시물 댓글을 삭제한다.',
   })
+  @ApiBearerAuth('access-token')
   @UseGuards(AuthGuard('jwt'))
   remove(@Param('commentId', ParseIntPipe) commentId: number, @Req() req) {
     return this.commentsService.removeComment(commentId);

--- a/back/src/habitat/habitat.controller.ts
+++ b/back/src/habitat/habitat.controller.ts
@@ -1,8 +1,19 @@
-import { Controller, Get, Post, Body, Param, Query, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  ParseIntPipe,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
 import { HabitatService } from './habitat.service';
 import { CreateHabitatDto } from './dto/create-habitat.dto';
-import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PaginationQueryDto } from 'common/dto/pagination-query.dto';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 
 @Controller('habitat')
 @ApiTags('서식지 API')
@@ -33,8 +44,10 @@ export class HabitatController {
     summary: '서식지 추가 API',
     description: '유저가 서식지를 추가한다.',
   })
-  createHabitat(@Body() createHabitatDto: CreateHabitatDto) {
-    return this.habitatService.createHabitat(createHabitatDto, 3);
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard)
+  createHabitat(@Body() createHabitatDto: CreateHabitatDto, @Req() req) {
+    return this.habitatService.createHabitat(createHabitatDto, req.user.userId);
   }
 
   @Get()

--- a/back/src/hearts/hearts.controller.ts
+++ b/back/src/hearts/hearts.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Query,
   UseGuards,
+  Req,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PaginationQueryDto } from 'common/dto/pagination-query.dto';
@@ -24,8 +25,8 @@ export class HeartsController {
   })
   @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard)
-  setHeart(@Param('postId', ParseIntPipe) postId: number) {
-    return this.heartsService.setHeart(postId, 2);
+  setHeart(@Param('postId', ParseIntPipe) postId: number, @Req() req) {
+    return this.heartsService.setHeart(postId, req.user.userId);
   }
 
   @Delete(':postId') //좋아요 삭제
@@ -35,8 +36,8 @@ export class HeartsController {
   })
   @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard)
-  deleteHeart(@Param('postId', ParseIntPipe) postId: number) {
-    return this.heartsService.deleteHeart(postId, 1);
+  deleteHeart(@Param('postId', ParseIntPipe) postId: number, @Req() req) {
+    return this.heartsService.deleteHeart(postId, req.user.userId);
   }
 
   @Get('count/:postId') // 좋아요 카운트

--- a/back/src/hearts/hearts.controller.ts
+++ b/back/src/hearts/hearts.controller.ts
@@ -2,15 +2,15 @@ import {
   Controller,
   Get,
   Post,
-  Body,
-  Patch,
   Param,
   Delete,
   ParseIntPipe,
   Query,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PaginationQueryDto } from 'common/dto/pagination-query.dto';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { HeartsService } from './hearts.service';
 @Controller('hearts')
 @ApiTags('좋아요 API')
@@ -22,6 +22,8 @@ export class HeartsController {
     summary: '좋아요 추가 API',
     description: '게시글 좋아요 누르기',
   })
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard)
   setHeart(@Param('postId', ParseIntPipe) postId: number) {
     return this.heartsService.setHeart(postId, 2);
   }
@@ -31,6 +33,8 @@ export class HeartsController {
     summary: '좋아요 취소 API',
     description: '게시글 좋아요 취소',
   })
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard)
   deleteHeart(@Param('postId', ParseIntPipe) postId: number) {
     return this.heartsService.deleteHeart(postId, 1);
   }
@@ -53,10 +57,7 @@ export class HeartsController {
     @Param('postId', ParseIntPipe) postId: number,
     @Query() paginationQueryDto: PaginationQueryDto
   ) {
-    return this.heartsService.getAllLikedUser(
-      postId,
-      paginationQueryDto
-    );
+    return this.heartsService.getAllLikedUser(postId, paginationQueryDto);
   }
 
   // @Get(':userId/:postId')

--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -4,11 +4,13 @@ import { AppModule } from './app.module';
 import * as cookieParser from 'cookie-parser';
 import * as morgan from 'morgan';
 import { loggerEnv } from 'config/logger.config';
+import * as dotenv from 'dotenv';
+dotenv.config();
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(morgan(loggerEnv));
-  app.enableCors();
+  if (process.env.NODE_ENV === 'dev') app.enableCors();
   app.setGlobalPrefix('api', { exclude: ['docs'] });
   app.use(cookieParser());
   const config = new DocumentBuilder()

--- a/back/src/post/post.controller.ts
+++ b/back/src/post/post.controller.ts
@@ -48,7 +48,7 @@ export class PostController {
   @ApiConsumes('multipart/form-data')
   @ApiBody({ type: CreatePostDto })
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption()))
+  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption))
   async uploadFile(
     @Body() createPostDto: CreatePostDto,
     @UploadedFiles() files: FileDto[],
@@ -109,7 +109,7 @@ export class PostController {
   @ApiBody({ type: PatchPostRequestDto })
   @ApiCreatedResponse({ type: Boolean })
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption()))
+  @UseInterceptors(FilesInterceptor('upload', 10, multerTransFormOption))
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() patchPostRequestDto: PatchPostRequestDto,

--- a/back/src/species/species.controller.ts
+++ b/back/src/species/species.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, UseGuards } from '@nestjs/common';
 import { SpeciesService } from './species.service';
 import { CreateSpeciesDto } from './dto/create-species.dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CursorPaginationDto } from 'common/dto/cursor-pagination.dto';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 
 @Controller('species')
 @ApiTags('동물카테고리 API')
@@ -14,6 +15,8 @@ export class SpeciesController {
     summary: '동물 카테고리 추가 API',
     description: '동물 카테고리 추가하기',
   })
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard)
   create(@Body() createSpeciesDto: CreateSpeciesDto) {
     return this.speciesService.create(createSpeciesDto);
   }

--- a/back/src/users/users.controller.ts
+++ b/back/src/users/users.controller.ts
@@ -99,7 +99,7 @@ export class UsersController {
   })
   @ApiConsumes('multipart/form-data')
   @ApiBody({ type: RegisterUserDto })
-  @UseInterceptors(FileInterceptor('upload', multerUserOption()))
+  @UseInterceptors(FileInterceptor('upload', multerUserOption))
   register(@Body(ParseUsernamePipe) createUserDto: CreateUserDto, @UploadedFile() image: FileDto) {
     return this.usersService.create(createUserDto, image);
   }
@@ -131,7 +131,7 @@ export class UsersController {
   @ApiConsumes('multipart/form-data')
   @ApiBody({ type: FileUploadDto })
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FileInterceptor('upload', multerUserOption()))
+  @UseInterceptors(FileInterceptor('upload', multerUserOption))
   updateImage(@UploadedFile() image: FileDto, @Req() req: any) {
     return this.usersService.updateImage(image, req.user);
   }

--- a/back/utils/s3.util.ts
+++ b/back/utils/s3.util.ts
@@ -2,10 +2,11 @@ import FileDto from 'common/dto/transformFileDto';
 import { CreateContentDto } from 'src/contents/dto/create-content.dto';
 
 export const getPartialFilesInfo = (files: Express.Multer.File[]) => {
-  const contentsInfos = files.map((v: FileDto, i: number) => {
+  const contentsInfos = files.map((file: FileDto, i: number) => {
+    const originFile = file.transforms.find((v) => v.id === 'origin');
     return {
-      url: v.transforms[0].location,
-      mimeType: v.mimetype,
+      url: originFile.location,
+      mimeType: 'image/webp',
     };
   });
   return contentsInfos;
@@ -13,9 +14,10 @@ export const getPartialFilesInfo = (files: Express.Multer.File[]) => {
 
 export const getPartialFileInfo = (file?: FileDto): CreateContentDto | undefined => {
   if (!file) return undefined;
+  const originFile = file.transforms.find((v) => v.id === 'origin');
   const contentInfo = {
-    url: file.transforms[0].location,
-    mimeType: file.mimetype,
+    url: originFile.location,
+    mimeType: 'image/webp',
   };
   return contentInfo;
 };


### PR DESCRIPTION
### 작업 내역
---
- [x] 이미지 URL에 feed나 profile이 붙는 버그수정
- [x] 이미지 uuid가 겹치는 버그수정
- [x] api 인증로직이 필요한 api 수정

### 고민 및 해결
---
- 이미지 uuid가 겹치는 이유는 nestJS가 앱시작시 의존성주입을 해서 uuid가 적용된 함수가 한번 실행되기 때문이었음
- 그래서 `origin`이미지와 `feed`이미지 or `profile`이미지와 같은 uuid를 공유하면서 매번 메소드 실행시에는 다른 uuid를 제공해주기 위해 삽질을 많이했음 ex) middleware를 구현하거나 등등...
- 하지만 갓 스택오버플로우에 비슷한 조건이 있어서 그걸로 해결

- URL뒤에 feed 나 profile이 붙는 이유는 db에 url을 추가할때 array[0]에 있는 값을 활용하는 로직으로 구현되어있었는데
- array의 순서가 랜덤하게 바뀌는걸 알아냄 -> array.find로 `origin`일 경우에만 url을 받아오게끔했음

- API 인증로직은 필요한것을 넣고 , swagger적용이 안되있는걸 일부수정함

- dot env 파일에서 dev, db_dev, production으로 구분


