### PR TITLE
[W6][D1][다람이] 댓글 관련 기능 구현 완료 / 버그 해결 / fetch 리팩토링

### DIFF
--- a/front/src/components/DetailModal/Comment.tsx
+++ b/front/src/components/DetailModal/Comment.tsx
@@ -10,7 +10,7 @@ import { Palette } from '@src/lib/styles/Palette';
 import { useUserState } from '@src/contexts/UserContext';
 import { formatDate } from '@lib/utils/time';
 import { InputModeState, InputModeAction, CommentAction } from './useCommentList';
-import { getAuthOption } from '@src/lib/utils/fetch';
+import { getAuthOption, fetchAPI } from '@src/lib/utils/fetch';
 
 interface CommentProps {
   nickname: string;
@@ -41,21 +41,20 @@ const Comment = ({ nickname, comment, inputMode, inputModeDispatch, commentDispa
   };
 
   const handleConfirmDelete = () => {
-    inputModeDispatch({ type: 'INIT_NORMAL_MODE' });
-    const fetchDelete = async () => {
-      const res: Response = await fetch(`/api/comments/${commentId}`, getAuthOption('DELETE', userState.data?.accessToken));
-      if (res.ok) {
+    fetchAPI(
+      `/api/comments/${commentId}`,
+      (res) => {
+        inputModeDispatch({ type: 'INIT_NORMAL_MODE' });
         commentDispatch({ type: 'REFRESH' });
-        return;
-      } else {
+      },
+      (res) => {
         console.log(res.status);
-      }
-    };
-    try {
-      fetchDelete();
-    } catch (err) {
-      console.log(err);
-    }
+      },
+      (err) => {
+        console.log(err);
+      },
+      getAuthOption('DELETE', userState.data?.accessToken)
+    );
   };
 
   return (

--- a/front/src/components/DetailModal/CommentForm.tsx
+++ b/front/src/components/DetailModal/CommentForm.tsx
@@ -4,20 +4,119 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { getAuthOption } from '@lib/utils/fetch';
 import { useUserState } from '@src/contexts/UserContext';
-import { CommentAction } from './useCommentList';
+import { CommentAction, InputModeState, InputModeAction } from './useCommentList';
+
+interface CommentFormProps {
+  feedId: number;
+  commentDispatch: React.Dispatch<CommentAction>;
+  inputMode: InputModeState;
+  inputModeDispatch: React.Dispatch<InputModeAction>;
+}
+
+const CommentForm = ({ inputMode, inputModeDispatch, commentDispatch, feedId }: CommentFormProps) => {
+  const [isActive, setActive] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const userState = useUserState();
+  const handleInputChange = () => {
+    const $input = inputRef.current;
+    if ($input) inputModeDispatch({ type: 'SET_INPUT_TEXT', data: { inputText: $input.value ?? '' } });
+  };
+
+  useEffect(() => {
+    if (inputRef.current !== null) inputRef.current.focus();
+  }, []);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.value = inputMode.inputText;
+      if (inputMode.inputText.length) setActive(true);
+      else setActive(false);
+    }
+  }, [inputMode]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isActive) {
+      return;
+    }
+    switch (inputMode.mode) {
+      case 'write':
+        const addComment = async () => {
+          const data = {
+            post_id: feedId,
+            content: inputRef.current?.value,
+          };
+          const res: Response = await fetch(`/api/comments`, getAuthOption('POST', userState.data?.accessToken, JSON.stringify(data), { 'Content-Type': 'application/json' }));
+
+          if (res.ok) {
+            commentDispatch({ type: 'REFRESH' });
+            inputModeDispatch({ type: 'INIT_NORMAL_MODE' });
+          } else {
+            console.log(res.status);
+          }
+        };
+        try {
+          addComment();
+        } catch (err) {
+          console.log(err);
+        }
+        return;
+      case 'delete':
+        return;
+      case 'edit':
+        inputModeDispatch({ type: 'INIT_NORMAL_MODE' });
+        const editComment = async () => {
+          const data = {
+            post_id: feedId,
+            content: inputMode.inputText,
+          };
+          const res: Response = await fetch(
+            `/api/comments/${inputMode.focusCommentId}`,
+            getAuthOption('PATCH', userState.data?.accessToken, JSON.stringify(data), { 'Content-Type': 'application/json' })
+          );
+          if (res.ok) {
+            commentDispatch({ type: 'REFRESH' });
+            return;
+          } else {
+            console.log(res.status);
+            return;
+          }
+        };
+        try {
+          editComment();
+        } catch (err) {
+          console.log(err);
+        }
+        return;
+      default:
+        throw new Error('unhandled mode');
+    }
+  };
+
+  return (
+    <UserForm onSubmit={handleSubmit}>
+      <UserInput mode={inputMode.mode} onChange={handleInputChange} ref={inputRef} placeholder={'댓글을 입력하세요.'} required />
+      <SubmitBtn type={'submit'} isActive={isActive}>
+        {isActive ? 'OK!' : 'X'}
+      </SubmitBtn>
+    </UserForm>
+  );
+};
+
+export default CommentForm;
 
 const UserForm = styled.form`
   ${flexBox('flex-start', 'center', 'row')};
   width: 100%;
 `;
 
-const UserInput = styled.textarea<{ editMode: boolean }>`
+const UserInput = styled.textarea<{ mode: 'write' | 'edit' | 'delete' }>`
   height: 50px;
   width: 100%;
   resize: none;
   font-size: 15px;
   padding: 3px 3px;
-  border: 1px solid ${(props) => (props.editMode ? Palette.RED : Palette.LIGHT_GRAY)};
+  border: 1px solid ${(props) => (props.mode === 'edit' ? Palette.RED : Palette.LIGHT_GRAY)};
   border-radius: 5px;
 `;
 
@@ -28,73 +127,3 @@ const SubmitBtn = styled.button<{ isActive: boolean }>`
   color: ${(props) => (props.isActive ? 'black' : Palette.LIGHT_GRAY)};
   font-weight: bold;
 `;
-
-interface CommentFormProps {
-  feedId: number;
-  editMode: boolean;
-  setInputText: React.Dispatch<React.SetStateAction<string>>;
-  inputText: string;
-  commentDispatch: React.Dispatch<CommentAction>;
-}
-
-const CommentForm = ({ editMode, inputText, setInputText, commentDispatch, feedId }: CommentFormProps) => {
-  const [isActive, setActive] = useState(false);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const userState = useUserState();
-  const handleInputChange = () => {
-    const $input = inputRef.current;
-    if ($input) setInputText($input.value);
-  };
-
-  useEffect(() => {
-    if (inputRef.current !== null) inputRef.current.focus();
-  }, [editMode]);
-
-  useEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.value = inputText;
-      if (inputText.length) setActive(true);
-      else setActive(false);
-    }
-  }, [inputText]);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!isActive) {
-      return;
-    }
-    if (editMode) {
-      return;
-    } else {
-      const addComment = async () => {
-        const data = {
-          post_id: feedId,
-          content: inputRef.current?.value,
-        };
-        const res: Response = await fetch(`/api/comments`, getAuthOption('POST', userState.data?.accessToken, JSON.stringify(data), { 'Content-Type': 'application/json' }));
-
-        if (res.ok) {
-          commentDispatch({ type: 'REFRESH' });
-        } else {
-          console.log(res.status);
-        }
-      };
-      try {
-        addComment();
-      } catch (err) {
-        console.log(err);
-      }
-    }
-  };
-
-  return (
-    <UserForm onSubmit={handleSubmit}>
-      <UserInput editMode={editMode} onChange={handleInputChange} ref={inputRef} placeholder={'댓글을 입력하세요.'} required />
-      <SubmitBtn type={'submit'} isActive={isActive}>
-        {isActive ? 'OK!' : 'X'}
-      </SubmitBtn>
-    </UserForm>
-  );
-};
-
-export default CommentForm;

--- a/front/src/components/DetailModal/DetailModal.tsx
+++ b/front/src/components/DetailModal/DetailModal.tsx
@@ -30,20 +30,9 @@ interface DetailModalProps {
 
 const DetailModal = ({ feedId, userId, userImgURL, imageURLs, nickname, text, ago, isHeart, numOfHearts }: DetailModalProps) => {
   const userState = useUserState();
-  const [editMode, setEditMode] = useState(false);
-  const [inputText, setInputText] = useState('');
-  const [commentState, commentDispatch] = useCommentList();
+  const { commentState, commentDispatch, inputMode, inputModeDispatch } = useCommentList();
   const [like, toggleLike] = useLike(isHeart, feedId);
   const { isShowing, toggle } = useModal();
-  const toggleEditMode = (text: string) => {
-    if (editMode) {
-      setEditMode(false);
-      setInputText('');
-    } else {
-      setEditMode(true);
-      setInputText(text);
-    }
-  };
 
   return (
     <DetailModalDiv>
@@ -62,9 +51,9 @@ const DetailModal = ({ feedId, userId, userImgURL, imageURLs, nickname, text, ag
           </FeedAuthorDiv>
           <p className={'text'}>{text}</p>
         </FeedInfoDiv>
-        <CommentList commentState={commentState} commentDispatch={commentDispatch} toggleEditMode={toggleEditMode} feedId={feedId} />
+        <CommentList commentState={commentState} commentDispatch={commentDispatch} inputMode={inputMode} inputModeDispatch={inputModeDispatch} feedId={feedId} />
         <HeartSection like={like!} toggleLike={userState.data?.userId !== -1 ? toggleLike : () => {}} numOfHearts={numOfHearts} />
-        <CommentForm inputText={inputText} commentDispatch={commentDispatch} setInputText={setInputText} editMode={editMode} feedId={feedId} />
+        <CommentForm commentDispatch={commentDispatch} inputMode={inputMode} inputModeDispatch={inputModeDispatch} feedId={feedId} />
       </CommunicateDiv>
       <Modal isShowing={isShowing} hide={toggle}>
         <AlertDiv>먼저 로그인 해주세요!</AlertDiv>

--- a/front/src/components/DetailModal/PreviewBox.tsx
+++ b/front/src/components/DetailModal/PreviewBox.tsx
@@ -30,7 +30,7 @@ const PreviewBox = ({ controller, imageURLs }: { controller: CarouselControl | u
       <SwipeBox gap={'10px'} height={'100%'} width={'100%'}>
         {imageURLs?.map((url, idx) => (
           <ImgDiv className={'button'} key={idx}>
-            <PreviewImg src={url.replace('feed', 'profile')} alt="test" data-idx={idx} onClick={handleImgClick} />
+            <PreviewImg src={url} alt="test" data-idx={idx} onClick={handleImgClick} />
           </ImgDiv>
         ))}
       </SwipeBox>

--- a/front/src/components/DetailModal/useCommentList.ts
+++ b/front/src/components/DetailModal/useCommentList.ts
@@ -1,6 +1,7 @@
 import { Comments } from '@src/types/Comment';
-import React, { useReducer } from 'react';
+import { useReducer } from 'react';
 
+// 댓글 목록 상태
 export interface CommentState {
   commentList: Comments;
   lastComment: number;
@@ -12,28 +13,71 @@ const initCommentState: CommentState = {
 };
 
 export interface CommentAction {
-  type: 'UPDATE_LAST_COMMENT' | 'UPDATE_COMMENT_LIST' | 'REFRESH' | 'INIT_COMMENT_LIST';
-  data?: Comments | number;
+  type: 'UPDATE_LAST_COMMENT' | 'UPDATE_COMMENT_LIST' | 'REFRESH' | 'INIT_COMMENT_LIST' | 'SET_MODE';
+  data?: Partial<CommentState>;
 }
 
-const reducer = (state: CommentState, action: CommentAction): CommentState => {
+const commentReducer = (state: CommentState, action: CommentAction): CommentState => {
   switch (action.type) {
     case 'UPDATE_COMMENT_LIST':
-      return { ...state, commentList: [...state.commentList, ...(action.data as Comments)] };
+      if (!action.data || !action.data.commentList) throw new Error('not enough data');
+      return { ...state, commentList: [...state.commentList, ...action.data.commentList] };
     case 'UPDATE_LAST_COMMENT':
-      return { ...state, lastComment: action.data as number };
+      if (!action.data || !action.data.lastComment) throw new Error('not enough data');
+      return { ...state, lastComment: action.data.lastComment };
     case 'REFRESH':
       return initCommentState;
     case 'INIT_COMMENT_LIST':
-      return { commentList: action.data as Comments, lastComment: 0 };
+      if (!action.data || !action.data.commentList) throw new Error('not enough data');
+      return { ...state, commentList: action.data.commentList, lastComment: 0 };
     default:
-      throw new Error('unhandled action');
+      throw new Error('unhandled action about comment reducer');
   }
 };
 
-const useCommentList = (): [CommentState, React.Dispatch<CommentAction>] => {
-  const [state, dispatch] = useReducer(reducer, initCommentState);
-  return [state, dispatch];
+// 입력폼 관련 상태
+type Mode = 'edit' | 'delete' | 'write';
+
+export interface InputModeState {
+  mode: Mode;
+  focusCommentId: null | number;
+  inputText: string;
+}
+
+const initModeState: InputModeState = {
+  mode: 'write',
+  focusCommentId: null,
+  inputText: '',
+};
+
+export interface InputModeAction {
+  type: 'SET_EDIT_MODE' | 'SET_DELETE_MODE' | 'INIT_NORMAL_MODE' | 'SET_INPUT_TEXT';
+  data?: Partial<InputModeState>;
+}
+
+const modeReducer = (state: InputModeState, action: InputModeAction): InputModeState => {
+  switch (action.type) {
+    case 'INIT_NORMAL_MODE':
+      return initModeState;
+    case 'SET_EDIT_MODE':
+      if (!action.data || !action.data.focusCommentId || !action.data.inputText) throw new Error('not enough data');
+      return { mode: 'edit', focusCommentId: action.data.focusCommentId, inputText: action.data.inputText };
+    case 'SET_DELETE_MODE':
+      if (!action.data || !action.data.focusCommentId) throw new Error('not enough data');
+      return { mode: 'delete', focusCommentId: action.data.focusCommentId, inputText: '' };
+    case 'SET_INPUT_TEXT':
+      if (!action.data || (!action.data.inputText && typeof action.data.inputText !== 'string')) throw new Error('not enough data');
+      return { ...state, inputText: action.data.inputText };
+    default:
+      throw new Error('unhandled action about mode reducer');
+  }
+};
+
+const useCommentList = () => {
+  const [commentState, commentDispatch] = useReducer(commentReducer, initCommentState);
+  const [inputMode, inputModeDispatch] = useReducer(modeReducer, initModeState);
+
+  return { commentState, commentDispatch, inputMode, inputModeDispatch };
 };
 
 export default useCommentList;

--- a/front/src/components/Feed/FeedContainer.tsx
+++ b/front/src/components/Feed/FeedContainer.tsx
@@ -27,7 +27,7 @@ const FeedContainerDiv = styled.div<Partial<HabitatInfo>>`
   box-sizing: border-box;
   gap: 20px;
   overflow-y: scroll;
-  z-index: 1;
+  z-index: 10;
 `;
 
 interface FeedScrollBoxProps {

--- a/front/src/lib/utils/fetch.ts
+++ b/front/src/lib/utils/fetch.ts
@@ -19,3 +19,21 @@ export const getAuthOption = (method: HTTPMethod, accessToken: string | undefine
 
   return { method: method, headers, body: data };
 };
+
+export const fetchAPI = async (fetchURL: string, okCallback: (res: Response) => void, failCallback: (res: Response) => void, errorCallback: (err: any) => void, fetchOption?: RequestInit) => {
+  try {
+    const response: Response = await fetch(fetchURL, fetchOption);
+    if (response.ok) {
+      okCallback(response);
+    } else {
+      // if(액세스 토큰 만료?) {
+      //   반환된 액세스 토큰 =  fetch(리프레시 토큰 유효성 테스트);
+      //   if(리프레시 토큰 역시 만료) throw err;
+      //   fetchAPI(다시 같은 요청, 반환된 액세스 토큰);
+      // }
+      failCallback(response);
+    }
+  } catch (err) {
+    errorCallback(err);
+  }
+};


### PR DESCRIPTION
### 작업 내역
---
- [ ] FAB, 모달 간 z index 관련 버그 해결
- [ ] 상세보기 스와이프 박스 postfix 관련 버그 해결
- [ ] 댓글 관련 로직 구현 완료
- [ ] fetch 리팩토링

### 고민 및 해결
---
1. 댓글 상태를 reducer로 다루고 있다. props를 아주 못생긴 방법으로 전달하고 있다. 컨택스트로 개선해야할지 고민중. 
2. fetch 예외처리 로직이 다 똑같은것 같아서 함수로 분리하였다. 리프레시 토큰에 대해서 fetchAPI 자체에서 처리하던가, refresh 관련 함수를 구현해서 failCallback에 넣어주는 방법 등으로 구현할 수 있을 것 같다.

### (필요시) 데모 이미지
---
