### PR TITLE
[W6][D1][징징이] file Input 로딩 창, 좋아요, useScroll 리팩토링

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -29,6 +29,9 @@ function App() {
             <MainPage />
           </UserProvider>
         </Route>
+        <Route>
+          <>에러페이지</>
+        </Route>
       </Switch>
     </>
   );

--- a/front/src/components/DetailModal/DetailContainer.tsx
+++ b/front/src/components/DetailModal/DetailContainer.tsx
@@ -1,9 +1,10 @@
 import DetailModal from '@components/DetailModal/DetailModal';
-import { Post } from '@src/types/Post';
+import { Post, Posts } from '@src/types/Post';
 import { formatDate } from '@lib/utils/time';
 import styled from 'styled-components';
 import { flexBox } from '@lib/styles/mixin';
 import { ToggleHandler } from '@common/Modal/useModal';
+import React, { Dispatch, SetStateAction } from 'react';
 
 const DetailContainerBlock = styled.div`
   ${flexBox('center', 'center')};
@@ -19,9 +20,11 @@ const DetailContainerBlock = styled.div`
 interface DetailContainerProps {
   detailFeed: Post;
   toggle: ToggleHandler;
+  setTotalPosts: Dispatch<SetStateAction<Posts>>;
+  setFeeds: Dispatch<SetStateAction<Posts>>;
 }
 
-const DetailContainer = ({ detailFeed, toggle }: DetailContainerProps) => {
+const DetailContainer = ({ detailFeed, toggle, setTotalPosts, setFeeds }: DetailContainerProps) => {
   const ago = formatDate(detailFeed!.created_at);
 
   return (
@@ -37,6 +40,8 @@ const DetailContainer = ({ detailFeed, toggle }: DetailContainerProps) => {
           numOfHearts={detailFeed.numOfHearts}
           isHeart={detailFeed.is_heart}
           ago={ago}
+          setTotalPosts={setTotalPosts}
+          setFeeds={setFeeds}
         />
       </div>
     </DetailContainerBlock>

--- a/front/src/components/DetailModal/DetailModal.tsx
+++ b/front/src/components/DetailModal/DetailModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import styled from 'styled-components';
 import { flexBox, prettyScroll } from '@lib/styles/mixin';
 import { Palette } from '@lib/styles/Palette';
@@ -14,6 +14,7 @@ import useCommentList from './useCommentList';
 import { useUserState } from '@src/contexts/UserContext';
 import Modal from '@common/Modal/Modal';
 import AlertDiv from '@common/Alert/AlertDiv';
+import { Posts } from '@src/types/Post';
 
 interface DetailModalProps {
   hide?: ToggleHandler;
@@ -26,14 +27,16 @@ interface DetailModalProps {
   numOfHearts: number;
   userImgURL: string | null;
   isHeart: 0 | 1;
+  setTotalPosts?: Dispatch<SetStateAction<Posts>>;
+  setFeeds?: Dispatch<SetStateAction<Posts>>;
 }
 
-const DetailModal = ({ feedId, userId, userImgURL, imageURLs, nickname, text, ago, isHeart, numOfHearts }: DetailModalProps) => {
+const DetailModal = ({ feedId, userId, userImgURL, imageURLs, nickname, text, ago, isHeart, numOfHearts, setTotalPosts, setFeeds }: DetailModalProps) => {
   const userState = useUserState();
   const [editMode, setEditMode] = useState(false);
   const [inputText, setInputText] = useState('');
   const [commentState, commentDispatch] = useCommentList();
-  const [like, toggleLike] = useLike(isHeart, feedId);
+  const [like, toggleLike] = useLike(isHeart, feedId, setTotalPosts, setFeeds);
   const { isShowing, toggle } = useModal();
   const toggleEditMode = (text: string) => {
     if (editMode) {

--- a/front/src/components/DetailModal/HeartSection.tsx
+++ b/front/src/components/DetailModal/HeartSection.tsx
@@ -17,7 +17,7 @@ const HeartSection = ({ like, toggleLike, numOfHearts }: HeartSectionProps) => {
   return (
     <HeartDiv>
       <HeartButton like={like} toggleLike={toggleLike} />
-      <span>{numOfHearts + (like ? 1 : 0)} likes</span>
+      <span>{+numOfHearts + (like ? 1 : 0)} likes</span>
     </HeartDiv>
   );
 };

--- a/front/src/components/Explore/Explore.tsx
+++ b/front/src/components/Explore/Explore.tsx
@@ -14,7 +14,7 @@ import { formatDate } from '@lib/utils/time';
 
 const Explore = ({ habitatInfo }: { habitatInfo: HabitatInfo | undefined | null }) => {
   const divRef = useRef<HTMLDivElement>(null);
-  const [totalFeed] = useFetchTotalFeeds(habitatInfo?.habitat.id);
+  const [totalFeed, _, setTotalPosts] = useFetchTotalFeeds(habitatInfo?.habitat.id);
   const [isReady, setReady] = useState(false);
   const [test, setTest] = useState<Post | null>(null);
   const { isShowing, toggle } = useModal();
@@ -47,6 +47,7 @@ const Explore = ({ habitatInfo }: { habitatInfo: HabitatInfo | undefined | null 
             userImgURL={test.user_image_url}
             numOfHearts={test.numOfHearts}
             isHeart={test.is_heart}
+            setTotalPosts={setTotalPosts}
           />
         )}
       </Modal>

--- a/front/src/components/Feed/Feed.tsx
+++ b/front/src/components/Feed/Feed.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as VertBtnSvg } from '@assets/icons/more_vert_btn.svg';
 import { ReactComponent as CommentBtnSvg } from '@assets/icons/comment_btn.svg';
@@ -20,6 +20,7 @@ import { Palette } from '@src/lib/styles/Palette';
 import { useHistory, useLocation } from 'react-router';
 import queryString from '@src/lib/utils/queryString';
 import AlertDiv from '@common/Alert/AlertDiv';
+import { Posts } from '@src/types/Post';
 
 export interface FeedProps {
   feedId: number;
@@ -35,13 +36,15 @@ export interface FeedProps {
   avatarImage: string | null;
   contentIds: number[];
   lazy?: (node: HTMLDivElement) => void;
+  setTotalPosts: Dispatch<SetStateAction<Posts>>;
+  setFeeds?: Dispatch<SetStateAction<Posts>>;
 }
 
-const Feed = ({ feedId, userId, nickname, imageURLs, contentIds, humanText, animalText, lazy, createdTime, is_heart, avatarImage, numOfComments }: FeedProps) => {
+const Feed = ({ feedId, userId, nickname, imageURLs, contentIds, humanText, animalText, lazy, createdTime, is_heart, avatarImage, numOfComments, setTotalPosts, setFeeds }: FeedProps) => {
   const { isShowing: isDeleteShowing, toggle: toggleDeleteModal } = useModal();
   const { isShowing: isEditShowing, toggle: toggleEditModal } = useModal();
   const { isShowing: isHeartErrorShowing, toggle: toggleErrorModal } = useModal();
-  const [like, toggleLike] = useLike(is_heart, feedId);
+  const [like, toggleLike] = useLike(is_heart, feedId, setTotalPosts, setFeeds);
   const ago = formatDate(createdTime);
   const items = makeDropBoxMenu([
     { text: '글 수정', handler: toggleEditModal },

--- a/front/src/components/Feed/FeedContainer.tsx
+++ b/front/src/components/Feed/FeedContainer.tsx
@@ -14,6 +14,7 @@ import DetailContainer from '@components/DetailModal/DetailContainer';
 import useDetailFeed from '@components/Feed/useDetailFeed';
 import Warning from '@common/Indicator/Warning';
 import Loading from '@common/Indicator/Loading';
+import { useScrollState } from '@src/contexts/ScrollContext';
 
 const FeedContainerDiv = styled.div<Partial<HabitatInfo>>`
   ${flexBox(null, null, 'column')};
@@ -46,7 +47,7 @@ const callback: IntersectionObserverCallback = (entries, observer) => {
 };
 
 const FeedContainer = ({ habitatInfo, curHabitatId }: FeedScrollBoxProps) => {
-  const { feeds, offset, height, handleScroll, setTotalPosts, setFeeds } = useScroll(curHabitatId);
+  const { handleScroll, setTotalPosts, setFeeds } = useScroll(curHabitatId);
   const [observerElement, observerRef] = useElementRef();
   const { toggle } = useModal('/detail/:id');
 
@@ -54,13 +55,9 @@ const FeedContainer = ({ habitatInfo, curHabitatId }: FeedScrollBoxProps) => {
     root: observerElement,
     rootMargin: '300px 0px',
   });
+  const { feeds, offset, height } = useScrollState();
+
   const detail = useDetailFeed(feeds);
-
-  feeds.forEach((feed) => {
-    console.log(feed.is_heart);
-  });
-
-  console.log(feeds);
 
   return (
     <FeedContainerDiv color={habitatInfo?.habitat.color} onScroll={handleScroll} ref={observerRef}>

--- a/front/src/components/Feed/FeedContainer.tsx
+++ b/front/src/components/Feed/FeedContainer.tsx
@@ -46,7 +46,7 @@ const callback: IntersectionObserverCallback = (entries, observer) => {
 };
 
 const FeedContainer = ({ habitatInfo, curHabitatId }: FeedScrollBoxProps) => {
-  const { feeds, offset, height, handleScroll } = useScroll(curHabitatId);
+  const { feeds, offset, height, handleScroll, setTotalPosts, setFeeds } = useScroll(curHabitatId);
   const [observerElement, observerRef] = useElementRef();
   const { toggle } = useModal('/detail/:id');
 
@@ -55,6 +55,12 @@ const FeedContainer = ({ habitatInfo, curHabitatId }: FeedScrollBoxProps) => {
     rootMargin: '300px 0px',
   });
   const detail = useDetailFeed(feeds);
+
+  feeds.forEach((feed) => {
+    console.log(feed.is_heart);
+  });
+
+  console.log(feeds);
 
   return (
     <FeedContainerDiv color={habitatInfo?.habitat.color} onScroll={handleScroll} ref={observerRef}>
@@ -78,6 +84,7 @@ const FeedContainer = ({ habitatInfo, curHabitatId }: FeedScrollBoxProps) => {
                   avatarImage={feed.user_image_url}
                   contentIds={feed.post_contents_ids.split(',').map((str) => parseInt(str))}
                   lazy={lazy}
+                  setTotalPosts={setTotalPosts}
                 />
               ))
             ) : (
@@ -90,7 +97,7 @@ const FeedContainer = ({ habitatInfo, curHabitatId }: FeedScrollBoxProps) => {
           )}
         </ViewPort>
       </ScrollContainer>
-      {detail && <DetailContainer detailFeed={detail} toggle={toggle} />}
+      {detail && <DetailContainer detailFeed={detail} toggle={toggle} setTotalPosts={setTotalPosts} setFeeds={setFeeds} />}
     </FeedContainerDiv>
   );
 };

--- a/front/src/components/Feed/useDetailFeed.ts
+++ b/front/src/components/Feed/useDetailFeed.ts
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Post, Posts } from '@src/types/Post';
 import { useLocation } from 'react-router-dom';
+import { getAuthOption } from '@lib/utils/fetch';
+import { useUserState } from '@src/contexts/UserContext';
 
 const useDetailFeed = (feeds: Posts) => {
   const [detail, setDetail] = useState<Post | null>(null);
+  const userState = useUserState();
   const location = useLocation();
 
   useEffect(() => {
@@ -22,7 +25,7 @@ const useDetailFeed = (feeds: Posts) => {
     else getFeed(id);
 
     async function getFeed(id: number) {
-      const response: Response = await fetch(`/api/posts/${id}`);
+      const response: Response = await fetch(`/api/posts/${id}`, getAuthOption('GET', userState.data?.accessToken));
       const detailFeed: Post = await response.json();
       detailFeed.contents_url_array = detailFeed.post_contents_urls.split(',').map((url) => url.replace('.webp', '-feed.webp'));
       setDetail(detailFeed);

--- a/front/src/components/HeartButton/HeartButton.tsx
+++ b/front/src/components/HeartButton/HeartButton.tsx
@@ -29,6 +29,7 @@ const HeartButtonDiv = styled.div<Partial<LikeProps>>`
 `;
 
 const HeartButton = ({ like, toggleLike }: LikeProps) => {
+  console.log(like);
   return (
     <HeartButtonDiv onClick={toggleLike} like={like}>
       {like ? <FillHeartSvg /> : <EmptyHeartSvg />}

--- a/front/src/components/HeartButton/HeartButton.tsx
+++ b/front/src/components/HeartButton/HeartButton.tsx
@@ -29,7 +29,6 @@ const HeartButtonDiv = styled.div<Partial<LikeProps>>`
 `;
 
 const HeartButton = ({ like, toggleLike }: LikeProps) => {
-  console.log(like);
   return (
     <HeartButtonDiv onClick={toggleLike} like={like}>
       {like ? <FillHeartSvg /> : <EmptyHeartSvg />}

--- a/front/src/components/HeartButton/useLike.ts
+++ b/front/src/components/HeartButton/useLike.ts
@@ -1,27 +1,78 @@
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { getAuthOption } from '@lib/utils/fetch';
 import { useUserState } from '@src/contexts/UserContext';
+import { Posts } from '@src/types/Post';
 
 export interface LikeProps {
   like: boolean;
   toggleLike: any;
 }
 
-export type UseLikeType = (isHeartString: 0 | 1, feedId: number) => [like: boolean, toggleLike: () => void];
+export type UseLikeType = (
+  isHeartString: 0 | 1,
+  feedId: number,
+  setTotalPosts: Dispatch<SetStateAction<Posts>> | undefined,
+  setFeeds: Dispatch<SetStateAction<Posts>> | undefined
+) => [like: boolean, toggleLike: () => void];
 
-export const useLike: UseLikeType = (isHeartString, feedId) => {
+export const useLike: UseLikeType = (isHeartString, feedId, setTotalPosts, setFeeds) => {
   const isHeart = isHeartString !== 0;
   const [like, setLike] = useState(isHeart);
   const userState = useUserState();
 
-  const toggleLike = () => {
+  const toggleLike = async () => {
     if (like) {
+      await fetch(`/api/hearts/${feedId}`, getAuthOption('DELETE', userState.data?.accessToken));
+
       setLike(false);
-      fetch(`/api/hearts/${feedId}`, getAuthOption('DELETE', userState.data?.accessToken));
+      if (setTotalPosts) {
+        setTotalPosts((posts) =>
+          posts.map((post) => {
+            if (post.post_id === feedId) {
+              return { ...post, is_heart: 0 };
+            }
+            return post;
+          })
+        );
+      }
+      if (setFeeds) {
+        setFeeds((feeds) =>
+          feeds.map((feed) => {
+            if (feed.post_id === feedId) {
+              return { ...feed, is_heart: 0 };
+            }
+            return feed;
+          })
+        );
+      }
+
       return;
     }
+    await fetch(`/api/hearts/${feedId}`, getAuthOption('POST', userState.data?.accessToken));
+
     setLike(true);
-    fetch(`/api/hearts/${feedId}`, getAuthOption('POST', userState.data?.accessToken));
+    if (setTotalPosts) {
+      setTotalPosts((posts) =>
+        posts.map((post) => {
+          if (post.post_id === feedId) {
+            return { ...post, is_heart: 1 };
+          }
+          return post;
+        })
+      );
+    }
+    if (setFeeds) {
+      setFeeds((feeds) =>
+        feeds.map((feed) => {
+          if (feed.post_id === feedId) {
+            console.log(feed);
+            return { ...feed, is_heart: 1 };
+          }
+          return feed;
+        })
+      );
+    }
+    return;
   };
 
   return [like, toggleLike];

--- a/front/src/components/Register/AccountInfo.tsx
+++ b/front/src/components/Register/AccountInfo.tsx
@@ -6,7 +6,7 @@ import Button from '@components/Button/Button';
 import logo from '@assets/images/logo2.png';
 import { RegisterState } from '@src/contexts/RegisterContext';
 import useForm, { Validation } from '@components/Register/useForm';
-import useFetchDuplicate from '@components/Register/useFetchDuplicate';
+import useFetchDuplicate from '@components/Register/useFetchVerification';
 import useFocus from '@hooks/useFocus';
 
 interface AccountInfoProps {

--- a/front/src/components/Register/MoreInfo.tsx
+++ b/front/src/components/Register/MoreInfo.tsx
@@ -15,7 +15,7 @@ import { RegisterState } from '@src/contexts/RegisterContext';
 import useForm, { Validation } from '@components/Register/useForm';
 import useGetFetch from '@hooks/useGetFetch';
 import HabitatsMakeModal from '@components/Register/HabitatsMakeModal';
-import useFetchDuplicate from '@components/Register/useFetchDuplicate';
+import useFetchDuplicate from '@components/Register/useFetchVerification';
 import useFocus from '@hooks/useFocus';
 
 interface MoreInfoProps {

--- a/front/src/components/Register/useFetchVerification.ts
+++ b/front/src/components/Register/useFetchVerification.ts
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 
-type UseFetchDuplicate = (path: string) => [boolean, (arg: string) => Promise<void>];
+type UseFetchVerification = (path: string) => [boolean, (arg: string) => Promise<void>];
 
-const useFetchDuplicate: UseFetchDuplicate = (path: string) => {
+const useFetchDuplicate: UseFetchVerification = (path: string) => {
   const [isDuplicate, setIsDuplicate] = useState(false);
 
   const handleCheckUsername = async (value: string) => {
-    const response: Response = await fetch(`/api/users/isDuplicated?${path}=${value}`);
+    const response: Response = await fetch(`/api/users/verification?${path}=${value}`);
     const result = await response.json();
     setIsDuplicate(result);
   };

--- a/front/src/components/User/UserAbout.tsx
+++ b/front/src/components/User/UserAbout.tsx
@@ -9,6 +9,8 @@ import { getAuthOption } from '@lib/utils/fetch';
 import { useUserState } from '@src/contexts/UserContext';
 import Modal from '@common/Modal/Modal';
 import AlertDiv from '@common/Alert/AlertDiv';
+import { ModalType } from '@src/types/Modal';
+import Button from '@components/Button/Button';
 
 interface UserAboutProps {
   userInfo: User | null;
@@ -16,10 +18,9 @@ interface UserAboutProps {
 
 const UserAbout = ({ userInfo }: UserAboutProps) => {
   const { data: userData } = useUserState();
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState<ModalType>(null);
 
   const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLoading(true);
     const target = e.target as HTMLInputElement;
     const file = target.files![0];
 
@@ -28,18 +29,25 @@ const UserAbout = ({ userInfo }: UserAboutProps) => {
     try {
       const response = await fetch('/api/users/contents', getAuthOption('PATCH', userData!.accessToken, data));
       await response.json();
-      setLoading(false);
-      window.location.reload();
+      setLoading('success');
+
+      setTimeout(() => {
+        window.location.reload();
+      }, 1500);
     } catch (e) {
-      setLoading(false);
+      setLoading('fail');
     }
+  };
+
+  const handleClick = () => {
+    setLoading('loading');
   };
 
   return (
     <UserAboutDiv>
       {userData?.userId === userInfo?.id ? (
         <Form>
-          <FileInsertLabel htmlFor="profile">
+          <FileInsertLabel htmlFor="profile" onClick={handleClick}>
             <AvatarDiv>
               <Avatar imgSrc={userInfo?.content?.url} size={'100%'} preventLink />
             </AvatarDiv>
@@ -66,9 +74,23 @@ const UserAbout = ({ userInfo }: UserAboutProps) => {
           '존재하지 않는 사용자입니다'
         )}
       </TextDiv>
-      {loading && (
+      {loading === 'loading' && (
         <Modal isShowing={true}>
-          <AlertDiv> 파일 업로드 중입니다.</AlertDiv>
+          <AlertDiv>프로필 사진 변경 중</AlertDiv>
+        </Modal>
+      )}
+      {loading === 'fail' && (
+        <Modal isShowing={true}>
+          <AlertDiv>다시 시도해주세요.</AlertDiv>
+          <Button borderColor={'black'} onClick={() => setLoading(null)} children={'확인'} />
+        </Modal>
+      )}
+      {loading === 'success' && (
+        <Modal isShowing={true}>
+          <AlertDiv>
+            <div>변경 성공!</div>
+            <Button borderColor={'black'} onClick={() => window.location.reload()} children={'확인'} />
+          </AlertDiv>
         </Modal>
       )}
     </UserAboutDiv>

--- a/front/src/contexts/RegisterContext.tsx
+++ b/front/src/contexts/RegisterContext.tsx
@@ -15,8 +15,8 @@ export interface RegisterState {
 }
 
 interface Action {
-  type: 'CHANGE_VALUE' | 'ADD_SPECIES' | 'ADD_HABITAT';
-  payload: {
+  type: 'CHANGE_VALUE' | 'ADD_SPECIES' | 'ADD_HABITAT' | 'RESET_VALUES';
+  payload?: {
     [propsName: string]: string;
   };
 }
@@ -40,6 +40,9 @@ const registerReducer = (state: RegisterState, { type, payload }: Action): Regis
     }
     case 'ADD_HABITAT': {
       return { ...state, habitatInfo: payload as HabitatInfo, habitatId: null };
+    }
+    case 'RESET_VALUES': {
+      return initialState;
     }
     default: {
       return state;

--- a/front/src/contexts/ScrollContext.tsx
+++ b/front/src/contexts/ScrollContext.tsx
@@ -1,0 +1,112 @@
+import { Posts, PostsResponse } from '@src/types/Post';
+import React, { createContext, useContext, useReducer } from 'react';
+import { getAuthOption } from '@lib/utils/fetch';
+
+const FIX_FEED = 5;
+const ITEM_HEIGHT = 650;
+
+interface scrollState {
+  startIndex: number;
+  scrollTop: number;
+  offset: number;
+  height: number;
+  feeds: Posts;
+  totalFeeds: Posts;
+  lastFeedId?: number;
+}
+
+interface Action {
+  type: 'CHANGE_SCROLL' | 'RESET_SCROLL' | 'CHANGE_TOTAL_FEEDS' | 'FETCH_POSTS' | 'RESET_FEEDS';
+  payload?: Partial<scrollState>;
+}
+
+const initialState: scrollState = {
+  startIndex: 0,
+  scrollTop: 0,
+  offset: 0,
+  height: 0,
+  feeds: [],
+  totalFeeds: [],
+};
+
+interface IFetchPost {
+  (habitat: number, lastFeedId?: number, accessToken?: string): Promise<Action>;
+}
+
+export const fetchPost: IFetchPost = async (habitat, lastFeedId, accessToken) => {
+  try {
+    console.log(habitat);
+    const response = await fetch(`/api/posts/habitats/${habitat}${lastFeedId ? `?lastPostId=${lastFeedId}` : ''}`, getAuthOption('GET', accessToken));
+    const data: PostsResponse = await response.json();
+
+    const postsData = data.posts.map((post) => ({ ...post, contents_url_array: post.post_contents_urls.split(',').map((url) => url.replace('.webp', '-feed.webp')) }));
+    return { type: 'FETCH_POSTS', payload: { totalFeeds: postsData } };
+  } catch (e: any) {
+    console.log(e);
+    return { type: 'FETCH_POSTS', payload: { totalFeeds: e } };
+  }
+};
+
+const reducer = (state: scrollState, { type, payload }: Action) => {
+  switch (type) {
+    case 'CHANGE_SCROLL': {
+      const scrollTop = payload!.scrollTop!;
+      const startIndex = Math.floor(scrollTop / ITEM_HEIGHT);
+      const offset = startIndex * ITEM_HEIGHT;
+      const feeds = state.totalFeeds.slice(startIndex, startIndex + FIX_FEED);
+
+      return { ...state, scrollTop, startIndex, feeds, offset: offset < 0 ? 0 : offset };
+    }
+    case 'CHANGE_TOTAL_FEEDS': {
+      const totalFeeds = [...state.totalFeeds, ...payload!.totalFeeds!];
+      const height = totalFeeds.length * ITEM_HEIGHT;
+      const feeds = totalFeeds.slice(state.startIndex, state.startIndex + FIX_FEED);
+
+      return { ...state, totalFeeds, height, feeds };
+    }
+    case 'FETCH_POSTS': {
+      const totalFeeds = [...state.totalFeeds, ...payload!.totalFeeds!];
+      const feeds = totalFeeds.slice(state.startIndex, state.startIndex + FIX_FEED);
+
+      return { ...state, totalFeeds, feeds };
+    }
+    case 'RESET_SCROLL': {
+      return { ...state, scrollTop: 0, offset: 0, height: 0 };
+    }
+    case 'RESET_FEEDS': {
+      return initialState;
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+const ScrollStateContext = createContext<scrollState | null>(null);
+const ScrollDispatchContext = createContext<React.Dispatch<Action> | null>(null);
+
+export const ScrollProvider = ({ children }: { children: React.ReactNode }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <ScrollDispatchContext.Provider value={dispatch}>
+      <ScrollStateContext.Provider value={state}>{children}</ScrollStateContext.Provider>
+    </ScrollDispatchContext.Provider>
+  );
+};
+
+export const useScrollState = () => {
+  const state = useContext(ScrollStateContext);
+  if (!state) {
+    throw new Error('user state context error');
+  }
+  return state;
+};
+
+export const useScrollDispatch = () => {
+  const dispatch = useContext(ScrollDispatchContext);
+  if (!dispatch) {
+    throw new Error('user dispatch context error');
+  }
+  return dispatch;
+};

--- a/front/src/hooks/useFetchTotalFeeds.ts
+++ b/front/src/hooks/useFetchTotalFeeds.ts
@@ -1,10 +1,13 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Posts, PostsResponse } from '@src/types/Post';
+import { getAuthOption } from '@lib/utils/fetch';
+import { useUserState } from '@src/contexts/UserContext';
 
-const useFetchTotalFeeds = (curHabitatId: number | undefined): [Posts, Dispatch<SetStateAction<number | null>>] => {
+const useFetchTotalFeeds = (curHabitatId: number | undefined): [Posts, Dispatch<SetStateAction<number | null>>, Dispatch<SetStateAction<Posts>>] => {
   const [feeds, setFeeds] = useState<Posts>([] as Posts);
   const [lastFeedId, setLastFeedId] = useState<number | null>(null);
   const [totalFeed, setTotalFeed] = useState<Posts>([] as Posts);
+  const userState = useUserState();
 
   useEffect(() => {
     setTotalFeed([]);
@@ -17,13 +20,16 @@ const useFetchTotalFeeds = (curHabitatId: number | undefined): [Posts, Dispatch<
 
     async function fetchData() {
       try {
-        const response: Response = await fetch(`/api/posts/habitats/${curHabitatId}${lastFeedId ? `?lastPostId=${lastFeedId}` : ''}`);
+        const response: Response = await fetch(`/api/posts/habitats/${curHabitatId}${lastFeedId ? `?lastPostId=${lastFeedId}` : ''}`, getAuthOption('GET', userState.data?.accessToken));
         const data: PostsResponse = await response.json();
 
         if (!data.posts.length) {
           setFeeds([]);
           return;
         }
+        data.posts.forEach((v) => {
+          console.log(v.is_heart);
+        });
 
         const postsData = data.posts.map((post) => ({ ...post, contents_url_array: post.post_contents_urls.split(',').map((url) => url.replace('.webp', '-feed.webp')) }));
 
@@ -38,7 +44,7 @@ const useFetchTotalFeeds = (curHabitatId: number | undefined): [Posts, Dispatch<
     setTotalFeed([...totalFeed, ...feeds]);
   }, [feeds]);
 
-  return [totalFeed, setLastFeedId];
+  return [totalFeed, setLastFeedId, setTotalFeed];
 };
 
 export default useFetchTotalFeeds;

--- a/front/src/hooks/useFetchTotalFeeds.ts
+++ b/front/src/hooks/useFetchTotalFeeds.ts
@@ -27,10 +27,6 @@ const useFetchTotalFeeds = (curHabitatId: number | undefined): [Posts, Dispatch<
           setFeeds([]);
           return;
         }
-        data.posts.forEach((v) => {
-          console.log(v.is_heart);
-        });
-
         const postsData = data.posts.map((post) => ({ ...post, contents_url_array: post.post_contents_urls.split(',').map((url) => url.replace('.webp', '-feed.webp')) }));
 
         setFeeds(postsData);

--- a/front/src/hooks/useScroll.ts
+++ b/front/src/hooks/useScroll.ts
@@ -1,78 +1,49 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { Posts } from '@src/types/Post';
-import useFetchTotalFeeds from '@hooks/useFetchTotalFeeds';
+import React, { useEffect } from 'react';
 import makeThrottle from '@lib/utils/makeThrottle';
+import { fetchPost, useScrollDispatch, useScrollState } from '@src/contexts/ScrollContext';
+import { useUserState } from '@src/contexts/UserContext';
 
-type UseScrollType = (curHabitatId: number) => {
-  offset: number;
-  height: number;
-  feeds: Posts;
-  handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
-  setTotalPosts: Dispatch<SetStateAction<Posts>>;
-  setFeeds: Dispatch<SetStateAction<Posts>>;
-};
-
-const ITEM_HEIGHT = 650;
-const FIX_FEED = 5;
-
-const useScroll: UseScrollType = (curHabitatId: number) => {
+const useScroll: any = (curHabitatId: number) => {
+  const dispatch = useScrollDispatch();
+  const scrollState = useScrollState();
+  const { data: userData } = useUserState();
   const throttleScroll = makeThrottle(350);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const target = e.target as Element;
 
     throttleScroll(() => {
-      setScroll((state) => ({ ...state, top: target.scrollTop }));
+      dispatch({ type: 'CHANGE_SCROLL', payload: { scrollTop: target.scrollTop } });
     });
   };
-
-  const [startIndex, setStartIndex] = useState(0);
-  const [feeds, setFeeds] = useState<Posts>([]);
-  const [scroll, setScroll] = useState({
-    top: 0,
-    offset: 0,
-    height: 0,
-  });
-  const [totalPosts, setLastFeedId, setTotalPosts] = useFetchTotalFeeds(curHabitatId);
-  const { top, offset, height } = scroll;
-
   useEffect(() => {
-    setScroll({ top: 0, offset: 0, height: 0 });
+    if (curHabitatId === undefined) {
+      return;
+    }
+    dispatch({ type: 'RESET_FEEDS' });
+
+    dispatchPostFetch();
+
+    async function dispatchPostFetch() {
+      await dispatch(await fetchPost(curHabitatId, undefined, userData?.accessToken));
+    }
   }, [curHabitatId]);
 
   useEffect(() => {
-    const startIndex = Math.floor(top / ITEM_HEIGHT);
-
-    setScroll({ ...scroll, height: totalPosts.length * ITEM_HEIGHT });
-    const nextFeeds = totalPosts.slice(startIndex, startIndex + FIX_FEED);
-
-    setFeeds(nextFeeds);
-  }, [totalPosts]);
-
-  useEffect(() => {
-    setStartIndex(Math.floor(top / ITEM_HEIGHT));
-  }, [top]);
-
-  useEffect(() => {
-    const nextOffset = startIndex * ITEM_HEIGHT;
-    setFeeds(totalPosts.slice(startIndex, startIndex + FIX_FEED));
-
-    setScroll({
-      ...scroll,
-      offset: nextOffset < 0 ? 0 : nextOffset,
-    });
-  }, [startIndex]);
-
-  useEffect(() => {
-    if (!(feeds.length && totalPosts.length)) {
+    const { feeds, totalFeeds } = scrollState;
+    if (!(feeds.length && totalFeeds.length)) {
       return;
     }
-    if (feeds[feeds.length - 1].post_id === totalPosts[totalPosts.length - 1].post_id) {
-      setLastFeedId(feeds[feeds.length - 1].post_id);
-    }
-  }, [feeds]);
+    dispatchPostFetch();
 
-  return { feeds, offset, height, handleScroll, setTotalPosts, setFeeds };
+    async function dispatchPostFetch() {
+      if (feeds[feeds.length - 1].post_id === totalFeeds[totalFeeds.length - 1].post_id) {
+        await dispatch(await fetchPost(curHabitatId, feeds[feeds.length - 1].post_id, userData?.accessToken));
+      }
+    }
+  }, [scrollState.feeds, scrollState.totalFeeds]);
+
+  return { handleScroll };
 };
 
 export default useScroll;

--- a/front/src/hooks/useScroll.ts
+++ b/front/src/hooks/useScroll.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Posts } from '@src/types/Post';
 import useFetchTotalFeeds from '@hooks/useFetchTotalFeeds';
 import makeThrottle from '@lib/utils/makeThrottle';
@@ -8,6 +8,8 @@ type UseScrollType = (curHabitatId: number) => {
   height: number;
   feeds: Posts;
   handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
+  setTotalPosts: Dispatch<SetStateAction<Posts>>;
+  setFeeds: Dispatch<SetStateAction<Posts>>;
 };
 
 const ITEM_HEIGHT = 650;
@@ -31,7 +33,7 @@ const useScroll: UseScrollType = (curHabitatId: number) => {
     offset: 0,
     height: 0,
   });
-  const [totalPosts, setLastFeedId] = useFetchTotalFeeds(curHabitatId);
+  const [totalPosts, setLastFeedId, setTotalPosts] = useFetchTotalFeeds(curHabitatId);
   const { top, offset, height } = scroll;
 
   useEffect(() => {
@@ -70,7 +72,7 @@ const useScroll: UseScrollType = (curHabitatId: number) => {
     }
   }, [feeds]);
 
-  return { feeds, offset, height, handleScroll };
+  return { feeds, offset, height, handleScroll, setTotalPosts, setFeeds };
 };
 
 export default useScroll;

--- a/front/src/hooks/useSideNavi.ts
+++ b/front/src/hooks/useSideNavi.ts
@@ -1,8 +1,6 @@
 import { useEffect, useReducer, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import queryString from '@lib/utils/queryString';
-
-const FETCH_HABITAT_LENGTH = 10;
 const INIT_HISTORY_INDEX = 4;
 
 interface HistoryState {
@@ -41,15 +39,20 @@ const reducer = (state: HistoryState, action: Action): HistoryState => {
 
 const useSideNavi = (userHabitatId: number) => {
   const [historyState, historyDispatch] = useReducer(reducer, initHistoryState);
+  const [error, setError] = useState(false);
   const getCurHabitat = (idx: number = 0) => historyState.habitatList[historyState.curIndex + idx] ?? undefined;
   const history = useHistory();
   const location = useLocation();
 
   const initRandomList = async (habitatId: number) => {
-    const res: Response = await fetch(`/api/habitat/random?currentId=${habitatId}`);
-    const data: number[] = await res.json();
-    data.splice(INIT_HISTORY_INDEX, 0, habitatId);
-    historyDispatch({ type: 'INIT_RANDOM_HABITAT', data });
+    try {
+      const res: Response = await fetch(`/api/habitat/random?currentId=${habitatId}`);
+      const data: number[] = await res.json();
+      data.splice(INIT_HISTORY_INDEX, 0, habitatId);
+      historyDispatch({ type: 'INIT_RANDOM_HABITAT', data });
+    } catch (e) {
+      setError(true);
+    }
   };
 
   useEffect(() => {
@@ -94,8 +97,8 @@ const useSideNavi = (userHabitatId: number) => {
   return {
     handleNextHabitat,
     handlePrevHabitat,
-    historyState,
     getCurHabitat,
+    error,
   };
 };
 

--- a/front/src/pages/MainPage.tsx
+++ b/front/src/pages/MainPage.tsx
@@ -12,6 +12,7 @@ import useHabitatInfo from '@hooks/useHabitatInfo';
 import MagicNumber from '@src/lib/styles/magic';
 import { useUserState } from '@src/contexts/UserContext';
 import useValidateUser from '@src/hooks/useValidateUser';
+import { ScrollProvider } from '@src/contexts/ScrollContext';
 
 const MainPage = () => {
   const userState = useUserState();
@@ -45,27 +46,29 @@ const MainPage = () => {
 
   return (
     <MainPageBlock>
-      <Header habitatInfo={habitatInfo} />
-      <MainContentsDiv ref={feedModeRef}>
-        {
+      <Header habitatInfo={habitatInfo} />{' '}
+      <ScrollProvider>
+        <MainContentsDiv ref={feedModeRef}>
           {
-            feed: (
-              <>
-                <FeedContainer habitatInfo={habitatInfo} curHabitatId={getCurHabitat()} />
-                <FeedFAB mode={mode} getPosFunc={getFeedFloatingPos} toggleMode={toggleMode} />
-                <HabitatPreview habitat={getCurHabitat(1)} onClick={handleNextHabitat} side={'right'} />
-                <HabitatPreview habitat={getCurHabitat(-1)} onClick={handlePrevHabitat} side={'left'} />
-              </>
-            ),
-            explore: (
-              <>
-                <Explore habitatInfo={habitatInfo} />
-                <FeedFAB mode={mode} getPosFunc={getExploreFloatingPos} toggleMode={toggleMode} />
-              </>
-            ),
-          }[mode]
-        }
-      </MainContentsDiv>
+            {
+              feed: (
+                <>
+                  <FeedContainer habitatInfo={habitatInfo} curHabitatId={getCurHabitat()} />
+                  <FeedFAB mode={mode} getPosFunc={getFeedFloatingPos} toggleMode={toggleMode} />
+                  <HabitatPreview habitat={getCurHabitat(1)} onClick={handleNextHabitat} side={'right'} />
+                  <HabitatPreview habitat={getCurHabitat(-1)} onClick={handlePrevHabitat} side={'left'} />
+                </>
+              ),
+              explore: (
+                <>
+                  <Explore habitatInfo={habitatInfo} />
+                  <FeedFAB mode={mode} getPosFunc={getExploreFloatingPos} toggleMode={toggleMode} />
+                </>
+              ),
+            }[mode]
+          }
+        </MainContentsDiv>{' '}
+      </ScrollProvider>
       <EmptyStyleDiv color={habitatInfo?.habitat.color} />
     </MainPageBlock>
   );

--- a/front/src/pages/MainPage.tsx
+++ b/front/src/pages/MainPage.tsx
@@ -19,9 +19,8 @@ const MainPage = () => {
 
   const [mode, setMode] = useState<'feed' | 'explore'>('feed');
   const feedModeRef = useRef<HTMLDivElement>(null);
+  const { getCurHabitat, handleNextHabitat, handlePrevHabitat, error } = useSideNavi(userState.data?.habitatId ?? 2);
 
-  // const { curHabitatId, handleNextHabitat, handlePrevHabitat, habitatList, historyIdx } = useSideNavi(userState.data?.habitatId as number);
-  const { getCurHabitat, handleNextHabitat, handlePrevHabitat, historyState } = useSideNavi(userState.data?.habitatId ?? 2);
   const { habitatInfo } = useHabitatInfo(getCurHabitat());
 
   const toggleMode = () => {
@@ -39,6 +38,10 @@ const MainPage = () => {
 
   const getFeedFloatingPos = () => (window.innerWidth + parseInt(MagicNumber.FEED_SECTION_WIDTH)) / 2 + 10;
   const getExploreFloatingPos = () => 0;
+
+  if (error) {
+    return <div>잘못된 경로입니다!</div>;
+  }
 
   return (
     <MainPageBlock>

--- a/front/src/types/Modal.ts
+++ b/front/src/types/Modal.ts
@@ -1,0 +1,1 @@
+export type ModalType = null | 'loading' | 'success' | 'fail';


### PR DESCRIPTION
### 작업 내역
---
- [x] 회원가입 중복체크 API path 수정
- [x] 간단한 에러페이지 차후 수정
- [x] 좋아요 (모달과 연동안되는 버그 있음)
- [x] useScroll 리팩토링

### 고민 및 해결
---

현재 피드의 모달을 띄워서 좋아요를 누르거나 취소한 후 모달창을 나오면 해당 피드와 연동이 안됨
서식지마다 스크롤 위치를 저장해놓는 기능이 욕심이나서 건드려보려했는데
useScroll이 너무 더러워서 reducer를 사용해 리팩토링부터 하고 구현하는 중
reducer와 비동기 함수를 같이 사용하는게 생각보다 깔끔하게 되지가 않는다. recoil이나 redux를 사용하는 이유를 조금은 알 것 같다
