### PR TITLE
[W6][D3][다람이] fetchAPI 적용 완료

### DIFF
--- a/front/src/components/DetailModal/CommentForm.tsx
+++ b/front/src/components/DetailModal/CommentForm.tsx
@@ -55,10 +55,6 @@ const CommentForm = ({ inputMode, inputModeDispatch, commentDispatch, feedId }: 
             inputModeDispatch({ type: 'INIT_NORMAL_MODE' });
           },
           (failResponse) => {
-            if (failResponse.status === 419) {
-              userDispatch({ type: 'LOGOUT_USER' });
-              history.push('/modal/login/');
-            }
             console.log(failResponse);
           },
           (err) => {

--- a/front/src/hooks/useFetchTotalFeeds.ts
+++ b/front/src/hooks/useFetchTotalFeeds.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Posts, PostsResponse } from '@src/types/Post';
-import { getAuthOption } from '@lib/utils/fetch';
+import { getAuthOption, fetchAPI } from '@lib/utils/fetch';
 import { useUserState } from '@src/contexts/UserContext';
 
 const useFetchTotalFeeds = (curHabitatId: number | undefined): [Posts, Dispatch<SetStateAction<number | null>>, Dispatch<SetStateAction<Posts>>] => {
@@ -16,24 +16,22 @@ const useFetchTotalFeeds = (curHabitatId: number | undefined): [Posts, Dispatch<
 
   useEffect(() => {
     if (curHabitatId === undefined) return;
-    fetchData();
 
-    async function fetchData() {
-      try {
-        const response: Response = await fetch(`/api/posts/habitats/${curHabitatId}${lastFeedId ? `?lastPostId=${lastFeedId}` : ''}`, getAuthOption('GET', userState.data?.accessToken));
-        const data: PostsResponse = await response.json();
-
+    fetchAPI(
+      `/api/posts/habitats/${curHabitatId}${lastFeedId ? `?lastPostId=${lastFeedId}` : ''}`,
+      async (okRes) => {
+        const data: PostsResponse = await okRes.json();
         if (!data.posts.length) {
           setFeeds([]);
           return;
         }
         const postsData = data.posts.map((post) => ({ ...post, contents_url_array: post.post_contents_urls.split(',').map((url) => url.replace('.webp', '-feed.webp')) }));
-
         setFeeds(postsData);
-      } catch (e) {
-        console.log(e);
-      }
-    }
+      },
+      (failRes) => {},
+      (err) => {},
+      getAuthOption('GET', userState.data?.accessToken)
+    );
   }, [lastFeedId, curHabitatId]);
 
   useEffect(() => {

--- a/front/src/hooks/useValidateUser.ts
+++ b/front/src/hooks/useValidateUser.ts
@@ -30,23 +30,6 @@ const useValidateUser = (userState: UserState) => {
       },
       getAuthOption('GET', accessToken)
     );
-    // const validFetch = async () => {
-    //   const res: Response = await fetch(`/api/users/info`, getAuthOption('GET', accessToken));
-    //   if (res.ok) {
-    //     const data = await res.json();
-    //     const newState: User = {
-    //       userId: data.id,
-    //       username: data.username,
-    //       nickname: data.nickname,
-    //       habitatId: data.habitatId,
-    //       speciesId: data.speciesId,
-    //       url: data.content?.url,
-    //       accessToken: accessToken!,
-    //     };
-    //     userDispatch({ type: 'GET_USER_SUCCESS', data: newState });
-    //   } else return;
-    // };
-    // validFetch();
   }, [userState]);
 };
 

--- a/front/src/lib/utils/fetch.ts
+++ b/front/src/lib/utils/fetch.ts
@@ -54,8 +54,8 @@ export const fetchAPI = async (fetchURL: string, okCallback: (res: Response) => 
           (failResponse) => {
             if (failResponse.status === 419) {
               localStorage.removeItem('access_token');
+              window.location.assign('/modal/login');
             }
-            console.log('adfadsfad', failResponse);
             failCallback(failResponse);
           },
           (err) => {
@@ -63,8 +63,7 @@ export const fetchAPI = async (fetchURL: string, okCallback: (res: Response) => 
             errorCallback(err);
           }
         );
-      }
-      failCallback(response);
+      } else failCallback(response);
     }
   } catch (err) {
     errorCallback(err);


### PR DESCRIPTION
### 작업 내역
---
- [ ] fetchAPI 로직 변경
- [ ] fetchAPI 적용 완료

### 고민 및 해결
---
1. accesstoken 만료 시 refresh 검증을 하고 failcallback도 실행하는 로직이었는데 ux가 구려서 failcallback 실행하지 않도록 변경
2. refreshtoken 만료 시 무조건 로그인 모달로 이동하도록 변경. 기존 코드는 모든 fetch 코드에서 failcallback으로 history 로직을 넘겨야했음.

### (필요시) 데모 이미지
---
